### PR TITLE
Feature/게시글 회원 신고 api #14

### DIFF
--- a/src/main/java/com/example/petstable/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/example/petstable/domain/member/entity/MemberEntity.java
@@ -3,6 +3,7 @@ package com.example.petstable.domain.member.entity;
 import com.example.petstable.domain.board.entity.BoardEntity;
 import com.example.petstable.domain.bookmark.entity.BookmarkEntity;
 import com.example.petstable.domain.pet.entity.PetEntity;
+import com.example.petstable.domain.report.entity.ReportEntity;
 import com.example.petstable.global.exception.PetsTableException;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,6 +32,7 @@ public class MemberEntity extends BaseTimeEntity {
     private String nickName; // 닉네임
 
     private String image_url; // 프로필 이미지
+    private int report_count; // 신고 횟수
 
     @Enumerated(value = EnumType.STRING)
     private SocialType socialType; // APPLE, GOOGLE
@@ -50,6 +52,9 @@ public class MemberEntity extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member")
     private List<BookmarkEntity> bookmarks;
+
+    @OneToMany(mappedBy = "reporter")
+    private List<ReportEntity> report;
 
     // 연관 관계 메서드
     public void addPets(PetEntity pet) {
@@ -87,5 +92,10 @@ public class MemberEntity extends BaseTimeEntity {
     // 프로필 사진 등록
     public void updateProfileImage(String imageUrl) {
         this.image_url = imageUrl;
+    }
+
+    // 사용자 신고횟수 증가
+    public void increaseReportCount() {
+        this.report_count++;
     }
 }

--- a/src/main/java/com/example/petstable/domain/report/controller/ReportController.java
+++ b/src/main/java/com/example/petstable/domain/report/controller/ReportController.java
@@ -1,0 +1,34 @@
+package com.example.petstable.domain.report.controller;
+
+import com.example.petstable.domain.report.dto.request.ReportPostRequest;
+import com.example.petstable.domain.report.dto.response.ReportPostResponse;
+import com.example.petstable.domain.report.service.ReportService;
+import com.example.petstable.global.auth.ios.auth.LoginUserId;
+import com.example.petstable.global.exception.PetsTableApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.petstable.domain.report.message.ReportMessage.*;
+
+@Tag(name = "신고 관련 컨트롤")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "게시글 신고")
+    @PostMapping("/post/{postId}")
+    @SecurityRequirement(name = "JWT")
+    public PetsTableApiResponse<ReportPostResponse> reportPost(@LoginUserId Long memberId, @PathVariable("postId") Long postId, @RequestBody @Valid ReportPostRequest request) {
+
+        ReportPostResponse response = reportService.reportPost(memberId, postId, request.getReportReason());
+
+        return PetsTableApiResponse.createResponse(response, REPORT_POST_SUCCESS);
+    }
+}

--- a/src/main/java/com/example/petstable/domain/report/dto/request/ReportPostRequest.java
+++ b/src/main/java/com/example/petstable/domain/report/dto/request/ReportPostRequest.java
@@ -1,0 +1,15 @@
+package com.example.petstable.domain.report.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportPostRequest {
+
+    @NotBlank(message = "공백일 수 없습니다.")
+    private String reportReason;
+}

--- a/src/main/java/com/example/petstable/domain/report/dto/response/ReportPostResponse.java
+++ b/src/main/java/com/example/petstable/domain/report/dto/response/ReportPostResponse.java
@@ -1,0 +1,13 @@
+package com.example.petstable.domain.report.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportPostResponse {
+
+    private int postReportCount;
+}

--- a/src/main/java/com/example/petstable/domain/report/entity/ReportEntity.java
+++ b/src/main/java/com/example/petstable/domain/report/entity/ReportEntity.java
@@ -1,0 +1,44 @@
+package com.example.petstable.domain.report.entity;
+
+import com.example.petstable.domain.board.entity.BoardEntity;
+import com.example.petstable.domain.member.entity.BaseTimeEntity;
+import com.example.petstable.domain.member.entity.MemberEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.*;
+
+@Getter
+@Entity
+@Table(name = "report") @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportEntity extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity reporter;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "board_id")
+    private BoardEntity post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_reason")
+    private ReportReason reportReason;
+
+    public ReportEntity(MemberEntity reporter, BoardEntity post, String reportReason) {
+        this.reporter = reporter;
+        this.post = post;
+        this.reportReason = ReportReason.from(reportReason);
+    }
+
+    public void setPost(BoardEntity post) {
+        this.post = post;
+        post.getReports().add(this);
+    }
+}

--- a/src/main/java/com/example/petstable/domain/report/entity/ReportReason.java
+++ b/src/main/java/com/example/petstable/domain/report/entity/ReportReason.java
@@ -1,0 +1,33 @@
+package com.example.petstable.domain.report.entity;
+
+import com.example.petstable.domain.report.message.ReportMessage;
+import com.example.petstable.global.exception.PetsTableException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.example.petstable.domain.report.message.ReportMessage.*;
+
+@AllArgsConstructor @NoArgsConstructor
+@Getter
+public enum ReportReason {
+
+    FISHING_HARASSMENT_SPAM("fishing_harassment_spam"),
+    LEAKING_FRAUD("leaking_fraud"),
+    PORNOGRAPHY("pornography"),
+    INAPPROPRIATE_CONTENT("inappropriate_content"),
+    INSULT("insult"),
+    COMMERCIAL_AD("commercial_ad"),
+    POLITICAL_CONTENT("political_content");
+
+    private String value;
+
+    public static ReportReason from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst().orElseThrow(() -> new PetsTableException(INVALID_REASON.getStatus(), INVALID_REASON.getMessage(), 400));
+    }
+}

--- a/src/main/java/com/example/petstable/domain/report/message/ReportMessage.java
+++ b/src/main/java/com/example/petstable/domain/report/message/ReportMessage.java
@@ -1,0 +1,20 @@
+package com.example.petstable.domain.report.message;
+
+import com.example.petstable.global.exception.ResponseMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportMessage implements ResponseMessage {
+
+    REPORT_POST_SUCCESS("해당 게시글 신고 완료", HttpStatus.OK),
+    SELF_REPORT_NOT_ALLOWED("내 게시글을 신고할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_REPORT("이미 신고한 게시글입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REASON("해당 신고 사유가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REPORT_POST("이미 신고한 게시글입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/example/petstable/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/petstable/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.example.petstable.domain.report.repository;
+
+import com.example.petstable.domain.report.entity.ReportEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
+}

--- a/src/main/java/com/example/petstable/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/petstable/domain/report/service/ReportService.java
@@ -1,0 +1,87 @@
+package com.example.petstable.domain.report.service;
+
+import com.example.petstable.domain.board.entity.BoardEntity;
+import com.example.petstable.domain.board.repository.BoardRepository;
+import com.example.petstable.domain.member.entity.MemberEntity;
+import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.report.dto.response.ReportPostResponse;
+import com.example.petstable.domain.report.entity.ReportEntity;
+import com.example.petstable.domain.report.repository.ReportRepository;
+import com.example.petstable.global.exception.PetsTableException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.petstable.domain.board.message.BoardMessage.*;
+import static com.example.petstable.domain.member.message.MemberMessage.MEMBER_NOT_FOUND;
+import static com.example.petstable.domain.report.message.ReportMessage.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    public ReportPostResponse reportPost(Long memberId, Long postId, String reportReason) {
+
+        MemberEntity reporter = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PetsTableException(MEMBER_NOT_FOUND.getStatus(), MEMBER_NOT_FOUND.getMessage(), 404));
+
+        BoardEntity post = boardRepository.findById(postId)
+                .orElseThrow(() -> new PetsTableException(POST_NOT_FOUND.getStatus(), POST_NOT_FOUND.getMessage(), 404));
+
+        createReport(reporter, post, reportReason);
+
+        // 만약 해당 게시글 작성자가 탈퇴한 경우
+        if (post.isMemberDeleted()) {
+
+            // 만약 해당 게시글의 신고 횟수가 5회 이상일 경우
+            if (post.isReportThresholdExceeded()) {
+                clearReportPost(post);
+            }
+
+        } else {
+            MemberEntity writer = post.getMember();
+            validateReporter(reporter, post);
+            validatePostThreshold(post);
+            writer.increaseReportCount();
+        }
+
+        return new ReportPostResponse(post.getReportCount());
+    }
+
+    public void createReport(MemberEntity reporter, BoardEntity post, String reportReason) {
+        ReportEntity report = new ReportEntity(reporter, post, reportReason);
+
+        // 만약 이미 신고한 게시글일 경우
+        if (post.hasAlreadyReported(reporter)) {
+            throw new PetsTableException(ALREADY_REPORT.getStatus(), ALREADY_REPORT.getMessage(), 400);
+        }
+
+        // 연관 관계 설정
+        post.addReport(report);
+        report.setPost(post);
+
+        reportRepository.save(report);
+    }
+
+    public void validateReporter(MemberEntity reporter, BoardEntity post) {
+        if (post.isWrittenBySelf(reporter)) {
+            throw new PetsTableException(SELF_REPORT_NOT_ALLOWED.getStatus(), SELF_REPORT_NOT_ALLOWED.getMessage(), 400);
+        }
+    }
+
+    public void validatePostThreshold(BoardEntity post) {
+        if (post.isReportThresholdExceeded()) {
+            clearReportPost(post);
+        }
+    }
+
+    public void clearReportPost(BoardEntity post) {
+        post.clearPost();
+    }
+}

--- a/src/test/java/com/example/petstable/service/ReportServiceTest.java
+++ b/src/test/java/com/example/petstable/service/ReportServiceTest.java
@@ -1,0 +1,178 @@
+package com.example.petstable.service;
+
+
+import com.example.petstable.domain.board.entity.BoardEntity;
+import com.example.petstable.domain.board.repository.BoardRepository;
+import com.example.petstable.domain.member.entity.MemberEntity;
+import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.report.dto.response.ReportPostResponse;
+import com.example.petstable.domain.report.service.ReportService;
+import com.example.petstable.global.exception.PetsTableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ReportServiceTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @DisplayName("게시글을 신고하면 게시글 작성자의 신고 횟수 및 게시글의 신고 횟수가 1회씩 증가한다")
+    @Test
+    void reportPost() {
+
+        // given
+        MemberEntity writer = MemberEntity.builder()
+                .nickName("악동")
+                .build();
+
+        MemberEntity reporter = MemberEntity.builder()
+                .nickName("쿠쿸")
+                .build();
+
+        memberRepository.saveAll(List.of(writer, reporter));
+
+        BoardEntity post = BoardEntity.builder()
+                .title("테스트")
+                .member(writer)
+                .build();
+
+        boardRepository.save(post);
+
+        // when
+        ReportPostResponse response = reportService.reportPost(reporter.getId(), post.getId(), "inappropriate_content");
+        MemberEntity actualMember = memberRepository.findById(writer.getId()).orElseThrow();
+        BoardEntity actualPost = boardRepository.findById(post.getId()).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(response.getPostReportCount()).isEqualTo(1),
+                () -> assertThat(actualMember.getReport_count()).isEqualTo(1),
+                () -> assertThat(actualPost.getReportCount()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("동일한 게시글을 2번 이상 신고할 경우 예외를 반환한다.")
+    @Test
+    void reportDuplicatePost() {
+
+        // given
+        MemberEntity writer = MemberEntity.builder()
+                .nickName("악동")
+                .build();
+
+        MemberEntity reporter = MemberEntity.builder()
+                .nickName("쿠쿸")
+                .build();
+
+        memberRepository.saveAll(List.of(writer, reporter));
+
+        BoardEntity post = BoardEntity.builder()
+                .title("테스트")
+                .member(writer)
+                .build();
+
+        boardRepository.save(post);
+
+        // when
+        reportService.reportPost(reporter.getId(), post.getId(), "inappropriate_content");
+
+        // then
+        assertThatThrownBy(
+                () -> reportService.reportPost(reporter.getId(), post.getId(), "insult"))
+                .isInstanceOf(PetsTableException.class);
+    }
+
+    @DisplayName("자신이 작성한 게시글을 신고할 경우 예외를 반환한다.")
+    @Test
+    void reportOwnPost() {
+        MemberEntity member = MemberEntity.builder()
+                .nickName("악동")
+                .build();
+
+        memberRepository.save(member);
+
+        BoardEntity post = BoardEntity.builder()
+                .title("테스트")
+                .member(member)
+                .build();
+
+        boardRepository.save(post);
+
+        assertThatThrownBy(
+                () -> reportService.reportPost(member.getId(), post.getId(), "insult"))
+                .isInstanceOf(PetsTableException.class);
+    }
+
+    @DisplayName("5번 이상 신고된 게시글은 삭제된다.")
+    @Test
+    void deletePostReportCountThresholdExceeded() {
+
+        // given
+        MemberEntity writer = MemberEntity.builder()
+                .nickName("악동")
+                .build();
+
+        MemberEntity reporter1 = MemberEntity.builder()
+                .nickName("신고자1")
+                .build();
+
+        MemberEntity reporter2 = MemberEntity.builder()
+                .nickName("신고자2")
+                .build();
+
+        MemberEntity reporter3 = MemberEntity.builder()
+                .nickName("신고자3")
+                .build();
+
+        MemberEntity reporter4 = MemberEntity.builder()
+                .nickName("신고자4")
+                .build();
+
+        MemberEntity reporter5 = MemberEntity.builder()
+                .nickName("신고자5")
+                .build();
+
+
+        memberRepository.saveAll(List.of(writer, reporter1, reporter2, reporter3, reporter4, reporter5));
+
+        BoardEntity post = BoardEntity.builder()
+                .title("테스트")
+                .member(writer)
+                .build();
+
+        boardRepository.save(post);
+
+        // when
+        reportService.reportPost(reporter1.getId(), post.getId(), "insult");
+        reportService.reportPost(reporter2.getId(), post.getId(), "insult");
+        reportService.reportPost(reporter3.getId(), post.getId(), "insult");
+        reportService.reportPost(reporter4.getId(), post.getId(), "insult");
+        reportService.reportPost(reporter5.getId(), post.getId(), "insult");
+
+        Long id = post.getId();
+
+        MemberEntity actualMember = memberRepository.findById(writer.getId()).orElseThrow();
+        BoardEntity actualPost = boardRepository.findById(id).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(actualMember.getReport_count()).isEqualTo(5),
+                () -> assertThat(actualPost.getTitle()).isNull()
+        );
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [[Feature] 게시글 및 회원 신고 API](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/14)

## 📝작업 내용

> 게시글을 신고하면 해당 게시글의 사용자, 게시글 모두 신고 횟수가 증가한다.
> 만약 게시글 누적 신고 횟수가 5회 이상일 경우 게시글을 DB에서 삭제하는 것이 아닌 null 로 update
