### PR TITLE
[feat] 서버 에러 ( 500 ) 발생 시 슬랙 알릭 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // Jackson Data Bind
     implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 
+    // Slack
+    implementation 'com.slack.api:slack-api-client:1.39.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/petstable/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/petstable/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.example.petstable.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/example/petstable/global/support/SlackService.java
+++ b/src/main/java/com/example/petstable/global/support/SlackService.java
@@ -1,0 +1,65 @@
+package com.example.petstable.global.support;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+@Slf4j
+@Component
+public class SlackService {
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    @Async
+    public void sendSlackError(Exception e, HttpServletRequest request) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                    .text("서버 에러 발생") // 메시지 제목
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request)) // 메시지 본문 내용
+                    )
+            ));
+        } catch (IOException slackError) {
+            log.debug("Slack과 통신 중 에러 발생");
+        }
+    }
+
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("FCCC00") // 색상
+                .title(requestTime + " 발생 에러 로그") // 메시지 본문 내용
+                .fields(List.of(
+                                generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() + "\n" : xffHeader + "\n"),
+                                generateSlackField("Request URL", request.getRequestURL() + " " + request.getMethod() + "\n"),
+                                generateSlackField("Error Message", e.getMessage())
+                        )
+                )
+                .build();
+    }
+
+    // slack field 생성
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
+    }
+}

--- a/src/test/java/com/example/petstable/service/SlackServiceTest.java
+++ b/src/test/java/com/example/petstable/service/SlackServiceTest.java
@@ -1,0 +1,31 @@
+package com.example.petstable.service;
+
+import com.example.petstable.global.support.SlackService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SlackServiceTest {
+
+    @Autowired
+    private SlackService slackService;
+
+    @DisplayName("에러 발생 시 슬랙 알람 테스트")
+    @Test
+    void sendSlackError() {
+
+        Exception testException = new Exception("Test exception");
+        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+
+        Mockito.when(mockRequest.getHeader("X-FORWARDED-FOR")).thenReturn(null);
+        Mockito.when(mockRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+        Mockito.when(mockRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost/test"));
+        Mockito.when(mockRequest.getMethod()).thenReturn("GET");
+
+        slackService.sendSlackError(testException, mockRequest);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [[feat] 서버 에러 ( 500 ) 발생 시 슬랙 알릭 기능 구현 #32 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/32) 

## 📝작업 내용

>서버 에러 ( Internal Server error ) 발생 시 슬랙으로 알림 보내지도록 비동기로 구현

### 스크린샷 (선택)
<img width="339" alt="스크린샷 2024-08-17 오전 1 43 31" src="https://github.com/user-attachments/assets/47f3b6e5-1ca9-4ca4-9962-9982e4144d02">