### PR TITLE
fix: 애플 로그인 오류 해결

### DIFF
--- a/src/main/java/com/example/petstable/domain/member/service/AuthService.java
+++ b/src/main/java/com/example/petstable/domain/member/service/AuthService.java
@@ -8,7 +8,8 @@ import com.example.petstable.domain.member.entity.Status;
 import com.example.petstable.domain.member.repository.MemberRepository;
 import com.example.petstable.global.auth.dto.request.OAuthLoginRequest;
 import com.example.petstable.global.auth.apple.AppleOAuthUserProvider;
-import com.example.petstable.global.auth.dto.response.OAuthMemberResponse;
+import com.example.petstable.global.auth.dto.response.AppleMemberResponse;
+import com.example.petstable.global.auth.dto.response.GoogleMemberResponse;
 import com.example.petstable.global.auth.JwtTokenProvider;
 import com.example.petstable.global.exception.PetsTableException;
 import com.example.petstable.global.refresh.dto.request.RefreshTokenRequest;
@@ -43,7 +44,7 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
 
     public TokenResponse appleOAuthLogin(OAuthLoginRequest request) {
-        OAuthMemberResponse appleSocialMember = appleOAuthUserProvider.getAppleMember(request.getToken());
+        AppleMemberResponse appleSocialMember = appleOAuthUserProvider.getAppleMember(request.getToken());
 
         return generateTokenResponse(SocialType.APPLE, appleSocialMember.getEmail(), appleSocialMember.getSocialId(), request.getFcmToken());
     }
@@ -58,7 +59,7 @@ public class AuthService {
             if (googleIdToken == null) {
                 throw new PetsTableException(INVALID_ID_TOKEN.getStatus(), INVALID_ID_TOKEN.getMessage(), 409);
             } else {
-                OAuthMemberResponse googleSocialMember = new OAuthMemberResponse(googleIdToken.getPayload());
+                GoogleMemberResponse googleSocialMember = new GoogleMemberResponse(googleIdToken.getPayload());
                 return generateTokenResponse(SocialType.GOOGLE, googleSocialMember.getEmail(), googleSocialMember.getSocialId(), request.getFcmToken());
             }
         } catch (GeneralSecurityException | IOException e) {

--- a/src/main/java/com/example/petstable/global/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/com/example/petstable/global/auth/apple/AppleClaimsValidator.java
@@ -25,7 +25,6 @@ public class AppleClaimsValidator {
     public boolean isValid(Claims claims) {;
 
         return claims.getIssuer().contains(iss) &&
-                claims.getAudience().contains(clientId) &&
-                claims.get(NONCE_KEY, String.class).equals(nonce);
+                claims.getAudience().contains(clientId);
     }
 }

--- a/src/main/java/com/example/petstable/global/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/com/example/petstable/global/auth/apple/AppleOAuthUserProvider.java
@@ -1,9 +1,10 @@
 package com.example.petstable.global.auth.apple;
 
-import com.example.petstable.global.auth.dto.response.OAuthMemberResponse;
+import com.example.petstable.global.auth.dto.response.AppleMemberResponse;
 import com.example.petstable.global.exception.PetsTableException;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.security.PublicKey;
@@ -20,7 +21,7 @@ public class AppleOAuthUserProvider {
     private final PublicKeyGenerator publicKeyGenerator;
     private final AppleClaimsValidator appleClaimsValidator;
 
-    public OAuthMemberResponse getAppleMember(String identityToken) {
+    public AppleMemberResponse getAppleMember(String identityToken) {
         Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
         ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
 
@@ -29,7 +30,7 @@ public class AppleOAuthUserProvider {
         Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
 
-        return new OAuthMemberResponse(claims.getSubject(), claims.get("email", String.class));
+        return new AppleMemberResponse(claims.getSubject(), claims.get("email", String.class));
     }
 
     private void validateClaims(Claims claims) {

--- a/src/main/java/com/example/petstable/global/auth/dto/response/AppleMemberResponse.java
+++ b/src/main/java/com/example/petstable/global/auth/dto/response/AppleMemberResponse.java
@@ -1,6 +1,5 @@
 package com.example.petstable.global.auth.dto.response;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,13 +7,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OAuthMemberResponse {
+public class AppleMemberResponse {
 
     private String socialId;
     private String email;
-
-    public OAuthMemberResponse(GoogleIdToken.Payload payload) {
-        this.socialId = payload.getSubject();
-        this.email = payload.getEmail();
-    }
 }

--- a/src/main/java/com/example/petstable/global/auth/dto/response/GoogleMemberResponse.java
+++ b/src/main/java/com/example/petstable/global/auth/dto/response/GoogleMemberResponse.java
@@ -1,0 +1,21 @@
+package com.example.petstable.global.auth.dto.response;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleMemberResponse {
+
+    private String socialId;
+    private String email;
+
+    public GoogleMemberResponse(GoogleIdToken.Payload payload) {
+        this.socialId = payload.getSubject();
+        this.email = payload.getEmail();
+    }
+}
+

--- a/src/test/java/com/example/petstable/apple/AppleOAuthProviderTest.java
+++ b/src/test/java/com/example/petstable/apple/AppleOAuthProviderTest.java
@@ -1,7 +1,7 @@
 package com.example.petstable.apple;
 
 import com.example.petstable.global.auth.apple.AppleOAuthUserProvider;
-import com.example.petstable.global.auth.dto.response.OAuthMemberResponse;
+import com.example.petstable.global.auth.dto.response.AppleMemberResponse;
 import com.example.petstable.global.auth.apple.AppleClaimsValidator;
 import com.example.petstable.global.auth.apple.AppleClient;
 import com.example.petstable.global.auth.apple.ApplePublicKeys;
@@ -62,7 +62,7 @@ public class AppleOAuthProviderTest {
         when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
         when(appleClaimsValidator.isValid(any())).thenReturn(true);
 
-        OAuthMemberResponse actual = appleOAuthUserProvider.getAppleMember(identityToken);
+        AppleMemberResponse actual = appleOAuthUserProvider.getAppleMember(identityToken);
         assertAll(
                 () -> assertThat(actual.getSocialId()).isEqualTo(expected),
                 () -> assertThat(actual.getEmail()).isEqualTo("ssg9505fj22@naver.com")

--- a/src/test/java/com/example/petstable/service/AuthServiceTest.java
+++ b/src/test/java/com/example/petstable/service/AuthServiceTest.java
@@ -8,7 +8,7 @@ import com.example.petstable.domain.member.repository.MemberRepository;
 import com.example.petstable.domain.member.service.AuthService;
 import com.example.petstable.global.auth.dto.request.OAuthLoginRequest;
 import com.example.petstable.global.auth.apple.AppleOAuthUserProvider;
-import com.example.petstable.global.auth.dto.response.OAuthMemberResponse;
+import com.example.petstable.global.auth.dto.response.AppleMemberResponse;
 import com.example.petstable.global.refresh.service.RefreshTokenService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -47,7 +47,7 @@ public class AuthServiceTest {
         String socialId = "20191476";
 
         when(appleOAuthUserProvider.getAppleMember(anyString()))
-                .thenReturn(new OAuthMemberResponse(socialId, expected));
+                .thenReturn(new AppleMemberResponse(socialId, expected));
 
         TokenResponse actual = authService.appleOAuthLogin(new OAuthLoginRequest("token", null));
 
@@ -76,7 +76,7 @@ public class AuthServiceTest {
         memberRepository.save(member);
 
         when(appleOAuthUserProvider.getAppleMember(anyString()))
-                .thenReturn(new OAuthMemberResponse(socialId, expected));
+                .thenReturn(new AppleMemberResponse(socialId, expected));
 
         TokenResponse actual = authService.appleOAuthLogin(new OAuthLoginRequest("token", null));
 
@@ -102,7 +102,7 @@ public class AuthServiceTest {
                 .build();
         memberRepository.save(member);
 
-        when(appleOAuthUserProvider.getAppleMember(anyString())).thenReturn(new OAuthMemberResponse(socialId, expected));
+        when(appleOAuthUserProvider.getAppleMember(anyString())).thenReturn(new AppleMemberResponse(socialId, expected));
 
         TokenResponse actual = authService.appleOAuthLogin(new OAuthLoginRequest("token", null));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> [fix: Apple Login 안 되는 오류 해결 #48 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/48)

## 📝작업 내용

> 애플, 구글 로그인 응답 데이터 분리
> ID Token 검증 시 nonce 값 비교 제거