### PR TITLE
fix: Cors 설정에 PATCH 메서드 허용 추가

### DIFF
--- a/src/main/java/com/example/petstable/global/config/CorsConfig.java
+++ b/src/main/java/com/example/petstable/global/config/CorsConfig.java
@@ -16,6 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
                         HttpMethod.HEAD.name(),
                         HttpMethod.POST.name(),
                         HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
                         HttpMethod.DELETE.name()
                 );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> [fix: PATCH 요청 시 403 에러 뜨는 거 해결 #63 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/63)

## 📝작업 내용

> Cors 설정 파일에 PATCH 메서드 허용 추가