### PR TITLE
refactor: TimeUnit 밀리초로 수정하고, RefreshToken 키를 memberId로 매핑하여 저장

### DIFF
--- a/src/main/java/com/example/petstable/domain/member/message/AuthMessage.java
+++ b/src/main/java/com/example/petstable/domain/member/message/AuthMessage.java
@@ -12,7 +12,7 @@ public enum AuthMessage implements ResponseMessage {
     BAD_REQUEST_PUBLIC_KEY("로그인 중 Public Key 생성에 문제가 발생했습니다..", HttpStatus.BAD_REQUEST),
     INVALID_ID_TOKEN("Id Token 값이 유효하지 않습니다", HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN("토큰 값이 유효하지 않습니다", HttpStatus.UNAUTHORIZED),
-    INVALID_REFRESH_TOKEN("올바르지 않은 Refresh Token 입니다/", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("올바르지 않은 Refresh Token 입니다.", HttpStatus.UNAUTHORIZED),
     NOT_EXPIRED_ACCESS_TOKEN("아직 만료되지 않은 액세스 토큰입니다", HttpStatus.BAD_REQUEST),
     EXPIRED_ID_TOKEN("Id Token 이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_TOKEN("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/example/petstable/global/refresh/service/RefreshTokenService.java
+++ b/src/main/java/com/example/petstable/global/refresh/service/RefreshTokenService.java
@@ -37,7 +37,8 @@ public class RefreshTokenService {
                 .expiration(validityRefreshTokenInMilliseconds)
                 .build();
 
-        redisTemplate.opsForValue().set(refreshToken, token, validityRefreshTokenInMilliseconds, TimeUnit.NANOSECONDS);
+        redisTemplate.opsForValue().set(refreshToken, token, validityRefreshTokenInMilliseconds, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set("memberId:" + memberId, refreshToken, validityRefreshTokenInMilliseconds, TimeUnit.MILLISECONDS);
     }
 
     public MemberEntity getMemberFromRefreshToken(String refreshToken) {
@@ -60,5 +61,7 @@ public class RefreshTokenService {
 
     public void updateToken(RefreshToken token) {
         redisTemplate.opsForValue().set(token.getRefreshToken(), token, token.getExpiration(), TimeUnit.MILLISECONDS);
+        redisTemplate.delete("memberId:" + token.getId());
+        redisTemplate.opsForValue().set("memberId:" + token.getId(), token, token.getExpiration(), TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> [refactor: RefreshToken 관련 로직 수정 #65 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/65)

## 📝작업 내용
1. TimeUnit 이 NANOSECONDS 로 되어있어, redis 에 저장되자마자 삭제되는 현상이 발생하여 TimeUnit 을 MILLISECONDS 로 변경
2. 기존엔 refreshToken 으로만 저장되었으나, 이로 인해 특정 사용자의 refreshToken 을 쉽게 조회하거나 삭제하는 데 어려움이 있어 memberId를 키로 매핑할 수 있도록 추가