### PR TITLE
feat: 레시피 상세 조회 응답 객체에 작성자 및 작성시간 추가

### DIFF
--- a/src/main/java/com/example/petstable/PetsTableApplication.java
+++ b/src/main/java/com/example/petstable/PetsTableApplication.java
@@ -2,10 +2,12 @@ package com.example.petstable;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class PetsTableApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
@@ -4,6 +4,7 @@ import com.example.petstable.domain.board.entity.BoardEntity;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,7 +14,9 @@ public class BoardDetailReadResponse {
 
     private Long id;
     private String title;
+    private String author;
     private int viewCount;
+    private LocalDateTime createdAt;
     private boolean bookmarkStatus;
     private List<DetailResponse> details;
     private List<TagResponse> tags;
@@ -45,7 +48,9 @@ public class BoardDetailReadResponse {
         return BoardDetailReadResponse.builder()
                 .id(boardEntity.getId())
                 .title(boardEntity.getTitle())
+                .author(boardEntity.getMember().getNickName())
                 .viewCount(boardEntity.getView_count())
+                .createdAt(boardEntity.getCreatedTime())
                 .bookmarkStatus(status)
                 .details(details)
                 .tags(tags)

--- a/src/main/java/com/example/petstable/domain/member/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/petstable/domain/member/entity/BaseTimeEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.security.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -17,9 +18,9 @@ public class BaseTimeEntity {
 
     @CreatedDate
     @Column(name = "created_time", updatable = false)
-    private Timestamp createdTime;
+    private LocalDateTime createdTime;
 
     @LastModifiedDate
     @Column(name = "modified_time")
-    private Timestamp modifiedTime;
+    private LocalDateTime modifiedTime;
 }

--- a/src/test/java/com/example/petstable/service/BoardServiceTest.java
+++ b/src/test/java/com/example/petstable/service/BoardServiceTest.java
@@ -30,10 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -174,10 +176,12 @@ public class BoardServiceTest {
 
         DescriptionRequest descriptionRequest = new DescriptionRequest("설명");
         TagRequest tagRequest = TagRequest.builder().tagType("기능별").tagName("모질개선").build();
+        IngredientRequest ingredientRequest = IngredientRequest.builder().name("당근").weight("30g").build();
 
         BoardPostRequest request = BoardPostRequest.builder()
                 .title("레시피 테스트")
                 .descriptions(List.of(descriptionRequest))
+                .ingredients(List.of(ingredientRequest))
                 .tags(List.of(tagRequest))
                 .build();
 
@@ -186,9 +190,14 @@ public class BoardServiceTest {
 
         // when
         BoardDetailReadResponse actual = boardService.findDetailByBoardId(member.getId(), post.getId());
+        LocalDateTime expectedCreatedTime = post.getCreatedTime();
 
         // then
-        assertThat(actual.getDetails().get(0).getImage_url()).isEqualTo("test_img.jpg");
+        assertAll(
+                () -> assertThat(actual.getDetails().get(0).getImage_url()).isEqualTo("test_img.jpg"),
+                () -> assertThat(actual.getAuthor()).isEqualTo("Seung-9"),
+                () -> assertThat(actual.getCreatedAt()).isEqualTo(expectedCreatedTime)
+        );
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 레시피 상세 조회 응답 객체 변경 #68 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/68)

## 📝작업 내용

1. BaseTimeEntity 에서 생성시간 및 변경시간을 TimeStamp -> LocalDateTime 으로 변경
2. @EnableJpaAuditing 어노테이션 추가
3. 응답 객체에 author 추가