### PR TITLE
chore: 중복 코드 삭제

### DIFF
--- a/src/main/java/com/example/petstable/domain/member/service/AuthService.java
+++ b/src/main/java/com/example/petstable/domain/member/service/AuthService.java
@@ -164,7 +164,6 @@ public class AuthService {
         if (member.getSocialType() == SocialType.APPLE) {
             appleOAuthUserProvider.revoke(appleWithdrawAuthCodeRequest.getAuthCode());
         } else if (member.getSocialType() == SocialType.GOOGLE) {
-            refreshTokenService.deleteRefreshTokenByMemberId(member.getId());
             googleOAuthUserProvider.revoke(appleWithdrawAuthCodeRequest.getAuthCode());
         } else {
             throw new PetsTableException(INVALID_SOCIAL.getStatus(), INVALID_SOCIAL.getMessage(), 400);


### PR DESCRIPTION
## #️⃣연관된 이슈

> [chore: 중복 코드 삭제 #72 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/72)

## 📝작업 내용

> 회원 탈퇴 시 Redis 에 저장되어 있는 refreshToken 을 지우는 코드가 중복되어 있어서 삭제함.