### PR TITLE
feat: 포인트 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -10,6 +10,7 @@ import com.example.petstable.domain.board.repository.TagRepository;
 import com.example.petstable.domain.bookmark.repository.BookmarkRepository;
 import com.example.petstable.domain.member.entity.MemberEntity;
 import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.point.service.PointService;
 import com.example.petstable.global.exception.PetsTableException;
 import com.example.petstable.global.support.AwsS3Uploader;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class BoardService {
     private final AwsS3Uploader awsS3Uploader;
     private final TagRepository tagRepository;
     private final IngredientRepository ingredientRepository;
+    private final PointService pointService;
 
     @Transactional
     public BoardPostResponse writePost(Long memberId, BoardPostRequest request, List<MultipartFile> images) {
@@ -60,6 +62,9 @@ public class BoardService {
         BoardEntity post = createPostWithDetailsAndTagsAndIngredientRequest(boardRequest, member);
 
         boardRepository.save(post);
+
+        // 포인트 증가
+        pointService.increasePoints(memberId);
 
         return BoardPostResponse.builder()
                 .title(post.getTitle())

--- a/src/main/java/com/example/petstable/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/petstable/domain/member/service/MemberService.java
@@ -9,6 +9,8 @@ import com.example.petstable.domain.member.dto.response.OAuthMemberSignUpRespons
 import com.example.petstable.domain.member.entity.MemberEntity;
 import com.example.petstable.domain.member.entity.SocialType;
 import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.point.entity.PointEntity;
+import com.example.petstable.domain.point.repository.PointRepository;
 import com.example.petstable.global.exception.PetsTableException;
 import com.example.petstable.global.support.AwsS3Uploader;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final PointRepository pointRepository;
     private final AwsS3Uploader awsS3Uploader;
 
     @Transactional
@@ -36,6 +39,8 @@ public class MemberService {
         SocialType socialType = SocialType.from(request.getSocialType());
         MemberEntity findMember = memberRepository.findBySocialTypeAndSocialId(socialType, request.getSocialId())
                 .orElseThrow(() -> new PetsTableException(MEMBER_NOT_FOUND.getStatus(), MEMBER_NOT_FOUND.getMessage(), 404));
+        PointEntity pointEntity = PointEntity.createPoint(findMember);
+        pointRepository.save(pointEntity);
 
         findMember.updateNickname(request.getNickname());
 

--- a/src/main/java/com/example/petstable/domain/point/controller/PointApi.java
+++ b/src/main/java/com/example/petstable/domain/point/controller/PointApi.java
@@ -1,0 +1,34 @@
+package com.example.petstable.domain.point.controller;
+
+import com.example.petstable.domain.point.dto.response.PointResponse;
+import com.example.petstable.global.auth.LoginUserId;
+import com.example.petstable.global.exception.PetsTableApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "포인트 관련 API")
+@SecurityRequirement(name = "JWT")
+public interface PointApi {
+
+    @Operation(summary = "포인트 조회 API", description = "나의 포인트를 조회합니다",
+            responses =  {
+                    @ApiResponse(responseCode = "200", content = @Content(
+                            schema = @Schema(implementation = PointResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "point": 10
+                            }
+                            """)
+                    ),
+                            description = "포인트 조회에 성공하였습니다."),
+                    @ApiResponse(responseCode = "404", description = "포인트 정보를 찾을 수 없습니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 오류가 발했습니다.", content = @Content)
+            })
+    PetsTableApiResponse<PointResponse> getMyPoint(@Parameter(hidden = true) @LoginUserId Long memberId);
+}

--- a/src/main/java/com/example/petstable/domain/point/controller/PointController.java
+++ b/src/main/java/com/example/petstable/domain/point/controller/PointController.java
@@ -1,0 +1,26 @@
+package com.example.petstable.domain.point.controller;
+
+import com.example.petstable.domain.point.dto.response.PointResponse;
+import com.example.petstable.domain.point.service.PointService;
+import com.example.petstable.global.auth.LoginUserId;
+import com.example.petstable.global.exception.PetsTableApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.petstable.domain.point.message.PointMessage.*;
+
+@RestController
+@RequestMapping("/point")
+@RequiredArgsConstructor
+public class PointController implements PointApi {
+
+    private final PointService pointService;
+
+    @GetMapping
+    public PetsTableApiResponse<PointResponse> getMyPoint(@LoginUserId Long memberId) {
+        PointResponse response = pointService.getPointByMemberId(memberId);
+        return PetsTableApiResponse.createResponse(response, SUCCESS_GET_POINT);
+    }
+}

--- a/src/main/java/com/example/petstable/domain/point/dto/response/PointResponse.java
+++ b/src/main/java/com/example/petstable/domain/point/dto/response/PointResponse.java
@@ -1,0 +1,10 @@
+package com.example.petstable.domain.point.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PointResponse {
+    private int point;
+}

--- a/src/main/java/com/example/petstable/domain/point/entity/PointEntity.java
+++ b/src/main/java/com/example/petstable/domain/point/entity/PointEntity.java
@@ -1,0 +1,43 @@
+package com.example.petstable.domain.point.entity;
+
+import com.example.petstable.domain.member.entity.MemberEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder()
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "points")
+public class PointEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "point_id")
+    private Long id;
+    private int point;
+
+    /**
+     * 추후 적립 내역 및 차감 내역 추가를 위한 확장성을 고려
+     */
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
+    public static PointEntity createPoint(MemberEntity member) {
+        return PointEntity.builder()
+                .member(member)
+                .point(0)
+//                .transactionType(transactionType)
+//                .description(description)
+                .build();
+    }
+
+    public void increasePoint() {
+        this.point += 10;
+    }
+}
+

--- a/src/main/java/com/example/petstable/domain/point/entity/TransactionType.java
+++ b/src/main/java/com/example/petstable/domain/point/entity/TransactionType.java
@@ -1,0 +1,12 @@
+package com.example.petstable.domain.point.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TransactionType {
+    POINT_GAINED("획득"), POINT_USED("차감");
+
+    private final String description;
+}

--- a/src/main/java/com/example/petstable/domain/point/message/PointMessage.java
+++ b/src/main/java/com/example/petstable/domain/point/message/PointMessage.java
@@ -1,0 +1,17 @@
+package com.example.petstable.domain.point.message;
+
+import com.example.petstable.global.exception.ResponseMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PointMessage implements ResponseMessage {
+
+    SUCCESS_GET_POINT("포인트 조회에 성공하였습니다..", HttpStatus.OK),
+    POINT_NOT_FOUND("해당 회원의 포인트 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/example/petstable/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/example/petstable/domain/point/repository/PointRepository.java
@@ -1,0 +1,14 @@
+package com.example.petstable.domain.point.repository;
+
+import com.example.petstable.domain.point.entity.PointEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PointRepository extends JpaRepository<PointEntity, Long> {
+
+    @Query("select p from PointEntity p where p.member.id = :memberId")
+    Optional<PointEntity> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/petstable/domain/point/service/PointService.java
+++ b/src/main/java/com/example/petstable/domain/point/service/PointService.java
@@ -1,0 +1,42 @@
+package com.example.petstable.domain.point.service;
+
+import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.point.dto.response.PointResponse;
+import com.example.petstable.domain.point.entity.PointEntity;
+import com.example.petstable.domain.point.repository.PointRepository;
+import com.example.petstable.global.exception.PetsTableException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.petstable.domain.member.message.MemberMessage.*;
+import static com.example.petstable.domain.point.message.PointMessage.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PointService {
+
+    private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
+    public PointResponse getPointByMemberId(Long memberId) {
+        PointEntity pointEntity = pointRepository.findByMemberId(memberId).orElseThrow(
+                () -> new PetsTableException(POINT_NOT_FOUND.getStatus(), POINT_NOT_FOUND.getMessage(), 404));
+
+        return PointResponse.builder()
+                .point(pointEntity.getPoint())
+                .build();
+    }
+
+    @Transactional
+    public void increasePoints(Long memberId) {
+        memberRepository.findById(memberId).orElseThrow(
+                () -> new PetsTableException(MEMBER_NOT_FOUND.getStatus(), MEMBER_NOT_FOUND.getMessage(), 404));
+
+        PointEntity pointEntity = pointRepository.findByMemberId(memberId).orElseThrow(
+                () -> new PetsTableException(POINT_NOT_FOUND.getStatus(), POINT_NOT_FOUND.getMessage(), 404));
+
+        pointEntity.increasePoint();
+    }
+}

--- a/src/test/java/com/example/petstable/service/PointServiceTest.java
+++ b/src/test/java/com/example/petstable/service/PointServiceTest.java
@@ -1,0 +1,52 @@
+package com.example.petstable.service;
+
+import com.example.petstable.domain.member.entity.MemberEntity;
+import com.example.petstable.domain.member.entity.SocialType;
+import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.domain.point.entity.PointEntity;
+import com.example.petstable.domain.point.repository.PointRepository;
+import com.example.petstable.domain.point.service.PointService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PointServiceTest {
+
+    @Autowired
+    private PointService pointService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Test
+    @DisplayName("포인트가 증가 및 조회에 성공한다.")
+    void increasePointTest() {
+        // given
+        MemberEntity member = MemberEntity.builder()
+                .email("test@apple.com")
+                .nickName("test")
+                .socialType(SocialType.APPLE)
+                .build();
+        memberRepository.save(member);
+
+        PointEntity pointEntity = PointEntity.createPoint(member);
+        pointRepository.save(pointEntity);
+
+        // when
+        int expected = 10;
+
+        pointService.increasePoints(member.getId());
+        int actual = pointService.getPointByMemberId(member.getId()).getPoint();
+        int actual2 = pointRepository.findByMemberId(member.getId()).orElseThrow().getPoint();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual2).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 포인트 API 구현 #74 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/74)

## 📝작업 내용

1. PointEntity 정의
2. 추후 포인트 적립 내역 및 차감 내역 조회를 위해 확장성을 고려한 ERD 설계
3. 포인트 조회 API 구현
4. 테스트 코드 작성