### PR TITLE
refactor: Swagger 문서 이름 수정 및 Google 로그인 오류 케이스 추가 및 게시글 작성 응답 데이터 최적화

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardPostResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardPostResponse.java
@@ -8,9 +8,6 @@ import java.util.List;
 @AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class BoardPostResponse {
-
+    private Long id;
     private String title;
-    private List<DetailPostResponse> details;
-    private List<TagResponse> tags;
-    private List<IngredientResponse> ingredients;
 }

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -67,28 +67,8 @@ public class BoardService {
         pointService.increasePoints(memberId);
 
         return BoardPostResponse.builder()
+                .id(post.getId())
                 .title(post.getTitle())
-                .details(post.getDetails().stream()
-                        .distinct() // 중복된 객체 제거
-                        .map(detail -> DetailPostResponse.builder()
-                                .image_url(detail.getImage_url())
-                                .description(detail.getDescription())
-                                .build())
-                        .collect(Collectors.toList()))
-                .tags(post.getTags().stream()
-                        .distinct() // 중복된 객체 제거
-                        .map(tag -> TagResponse.builder()
-                                .tagType(tag.getType())
-                                .tagName(tag.getName())
-                                .build())
-                        .collect(Collectors.toList()))
-                .ingredients(post.getIngredients().stream()
-                        .distinct()
-                        .map(ingredient -> IngredientResponse.builder()
-                                .name(ingredient.getName())
-                                .weight(ingredient.getWeight())
-                                .build())
-                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/example/petstable/domain/member/service/AuthService.java
+++ b/src/main/java/com/example/petstable/domain/member/service/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
                 GoogleMemberResponse googleSocialMember = new GoogleMemberResponse(googleIdToken.getPayload());
                 return generateTokenResponse(SocialType.GOOGLE, googleSocialMember.getEmail(), googleSocialMember.getSocialId(), request.getFcmToken());
             }
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (GeneralSecurityException | IOException | IllegalArgumentException e) {
             throw new PetsTableException(INVALID_ID_TOKEN.getStatus(), INVALID_ID_TOKEN.getMessage(), 409);
         }
     }

--- a/src/main/java/com/example/petstable/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/petstable/global/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import java.util.List;
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "Default Server URL"),
         info = @Info(
-                title = "PetsTable 백엔드 API 명세",
+                title = "DogKer 백엔드 API 명세",
                 description = "springdoc을 이용한 Swagger API 문서입니다.",
                 version = "1.0",
                 contact = @Contact(


### PR DESCRIPTION
## #️⃣연관된 이슈

> [refactor: Swagger 문서 이름 수정 및 Google 로그인 오류 케이스 추가 및 게시글 작성 응답 데이터 최적화 #77 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/77)

## 📝작업 내용
> Swagger 문서 이름 수정
> 게시글 작성 시 response로 반환되는 데이터 수정
> Google Login 시 발생하는 에러 케이스 추가