### PR TITLE
feat: 검색 필터링 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,30 @@ dependencies {
     // Slack
     implementation 'com.slack.api:slack-api-client:1.39.0'
 
+    // querydsl for spring boot 3.x
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Querydsl 설정부
+    def generated = 'src/main/generated'
+
+    // querydsl QClass 파일 생성 위치를 지정
+    tasks.withType(JavaCompile) {
+        options.getGeneratedSourceOutputDirectory().set(file(generated))
+    }
+
+// java source set 에 querydsl QClass 위치 추가
+    sourceSets {
+        main.java.srcDirs += [ generated ]
+    }
+
+// gradle clean 시에 QClass 디렉토리 삭제
+    clean {
+        delete file(generated)
+    }
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
@@ -1,13 +1,7 @@
 package com.example.petstable.domain.board.controller;
 
-import com.example.petstable.domain.board.dto.request.BoardPostRequest;
-import com.example.petstable.domain.board.dto.request.BoardUpdateTagRequest;
-import com.example.petstable.domain.board.dto.request.BoardUpdateTitleRequest;
-import com.example.petstable.domain.board.dto.request.DetailUpdateRequest;
-import com.example.petstable.domain.board.dto.response.BoardDetailReadResponse;
-import com.example.petstable.domain.board.dto.response.BoardPostResponse;
-import com.example.petstable.domain.board.dto.response.BoardReadAllResponse;
-import com.example.petstable.domain.board.dto.response.DetailResponse;
+import com.example.petstable.domain.board.dto.request.*;
+import com.example.petstable.domain.board.dto.response.*;
 import com.example.petstable.global.auth.LoginUserId;
 import com.example.petstable.global.exception.PetsTableApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -117,6 +112,66 @@ public interface BoardApi {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
     })
     PetsTableApiResponse<BoardReadAllResponse> readAllPost(
+            Pageable pageable,
+            @Parameter(hidden = true) @LoginUserId Long memberId
+    );
+
+    @Operation(summary = "특정 조건으로 검색 및 정렬된 레시피 게시글 조회 API",
+            description = "제목 또는 내용 혹은 태그 이름과 재료로 레시피 게시글을 검색합니다.\n 인기순/최신순 으로 정렬하기 위해선 sort 에 createdTime / mostViewed 넣으면 됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            content = @Content(
+                                    schema = @Schema(implementation = BoardReadWithBookmarkResponse.class),
+                                    examples = @ExampleObject(value = """
+                                     {
+                                       "recipes": [
+                                         {
+                                           "id": 1,
+                                           "title": "건강한 수제 간식 만들기",
+                                           "imageUrl": "https://example.com/image1.jpg",
+                                           "bookmarkStatus": true,
+                                           "tagName": [
+                                             "모질개선",
+                                             "저알러지"
+                                           ]
+                                         },
+                                         {
+                                           "id": 2,
+                                           "title": "포메라니안을 위한 건강 수프",
+                                           "imageUrl": "https://example.com/image2.jpg",
+                                           "bookmarkStatus": false,
+                                           "tagName": [
+                                             "체중조절",
+                                             "영양강화"
+                                           ]
+                                         }
+                                       ],
+                                       "pageResponse": {
+                                         "totalPages": 10,
+                                         "currentPage": 1,
+                                         "totalElements": 100,
+                                         "isPageLast": false,
+                                         "size": 10,
+                                         "numberOfElements": 10,
+                                         "isPageFirst": true,
+                                         "isEmpty": false
+                                       }
+                                     }
+                                     """)
+                            ),
+                            description = "레시피 게시글 조회에 성공하였습니다."
+                    ),
+                    @ApiResponse(responseCode = "401",
+                            description = "액세스 토큰이 올바르지 않습니다.",
+                            content = @Content),
+                    @ApiResponse(responseCode = "500",
+                            description = "서버 내부 오류입니다.",
+                            content = @Content)
+            })
+    PetsTableApiResponse<List<BoardReadWithBookmarkResponse>> readPostsByFiltering(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) List<String> tagNames,
+            @RequestParam(required = false) List<String> ingredientNames,
             Pageable pageable,
             @Parameter(hidden = true) @LoginUserId Long memberId
     );

--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -1,10 +1,7 @@
 package com.example.petstable.domain.board.controller;
 
 import com.example.petstable.domain.board.dto.request.*;
-import com.example.petstable.domain.board.dto.response.BoardDetailReadResponse;
-import com.example.petstable.domain.board.dto.response.BoardPostResponse;
-import com.example.petstable.domain.board.dto.response.BoardReadAllResponse;
-import com.example.petstable.domain.board.dto.response.DetailResponse;
+import com.example.petstable.domain.board.dto.response.*;
 import com.example.petstable.domain.board.service.BoardService;
 import com.example.petstable.global.auth.LoginUserId;
 import com.example.petstable.global.exception.PetsTableApiResponse;
@@ -42,6 +39,22 @@ public class BoardController implements BoardApi {
         return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
     }
 
+    @GetMapping("/search")
+    public PetsTableApiResponse<List<BoardReadWithBookmarkResponse>> readPostsByFiltering(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "tagNames", required = false) List<String> tagNames,
+            @RequestParam(value = "ingredientNames", required = false) List<String> ingredientNames,
+            Pageable pageable, @LoginUserId Long memberId) {
+        BoardFilteringRequest request = new BoardFilteringRequest(keyword, tagNames, ingredientNames);
+        if (request.getKeyword() != null) {
+            List<BoardReadWithBookmarkResponse> response = boardService.findPostsByTitleAndContent(request, pageable, memberId);
+            return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
+        } else {
+            List<BoardReadWithBookmarkResponse> response = boardService.findPostsByTagAndIngredients(request, pageable, memberId);
+            return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
+        }
+    }
+
     @GetMapping("/{boardId}")
     public PetsTableApiResponse<BoardDetailReadResponse> getPostDetail(@LoginUserId Long memberId, @PathVariable("boardId") Long boardId) {
 
@@ -49,6 +62,7 @@ public class BoardController implements BoardApi {
 
         return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
     }
+
 
     @DeleteMapping(value = "/{boardId}")
     public ResponseEntity<String> deletePostDetail (@LoginUserId Long userId, @PathVariable("boardId") Long boardId) {

--- a/src/main/java/com/example/petstable/domain/board/dto/request/BoardFilteringRequest.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/request/BoardFilteringRequest.java
@@ -1,0 +1,21 @@
+package com.example.petstable.domain.board.dto.request;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardFilteringRequest {
+    @Schema(description = "제목", example = "수제 간식")
+    private String keyword; // 제목 혹은 내용
+
+    @ArraySchema(schema = @Schema(description = "태그 이름"))
+    private List<String> tagNames; // 태그
+
+    @ArraySchema(schema = @Schema(description = "재료 이름"))
+    private List<String> ingredients; // 재료
+}

--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardReadWithBookmarkResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardReadWithBookmarkResponse.java
@@ -1,6 +1,7 @@
 package com.example.petstable.domain.board.dto.response;
 
 import com.example.petstable.domain.board.entity.BoardEntity;
+import com.example.petstable.domain.board.entity.IngredientEntity;
 import com.example.petstable.domain.board.entity.TagEntity;
 import lombok.*;
 
@@ -16,15 +17,24 @@ public class BoardReadWithBookmarkResponse {
     private String imageUrl; // 썸네일 이미지
     private boolean bookmarkStatus;
     private List<String> tagName; // 태그 이름 목록
+    private List<String> ingredient; // 재료 이름 목록
 
     public BoardReadWithBookmarkResponse(BoardEntity post, boolean status) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.imageUrl = post.getThumbnail_url();
         this.bookmarkStatus = status;
-        this.tagName = post.getTags()
-                .stream()
-                .map(TagEntity::getName)
-                .toList();
+        if (post.getTags() != null) {
+            this.tagName = post.getTags()
+                    .stream()
+                    .map(TagEntity::getName)
+                    .toList();
+        }
+        if (post.getIngredients() != null) {
+            this.ingredient =post.getIngredients()
+                    .stream()
+                    .map(IngredientEntity::getName)
+                    .toList();
+        }
     }
 }

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepository.java
@@ -1,0 +1,13 @@
+package com.example.petstable.domain.board.repository;
+
+import com.example.petstable.domain.board.dto.request.BoardFilteringRequest;
+import com.example.petstable.domain.board.dto.response.BoardReadWithBookmarkResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface BoardCustomRepository {
+
+    List<BoardReadWithBookmarkResponse> findRecipesByQueryDslWithTitleAndContent(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable);
+    List<BoardReadWithBookmarkResponse> findRecipesByQueryDslWithTagAndIngredients(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepositoryImpl.java
@@ -1,0 +1,141 @@
+package com.example.petstable.domain.board.repository;
+
+import com.example.petstable.domain.board.dto.request.BoardFilteringRequest;
+import com.example.petstable.domain.board.dto.response.BoardReadWithBookmarkResponse;
+import com.example.petstable.domain.board.entity.BoardEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.petstable.domain.board.entity.QBoardEntity.boardEntity;
+import static com.example.petstable.domain.board.entity.QDetailEntity.detailEntity;
+import static com.example.petstable.domain.board.entity.QIngredientEntity.ingredientEntity;
+import static com.example.petstable.domain.board.entity.QTagEntity.tagEntity;
+import static com.example.petstable.domain.bookmark.entity.QBookmarkEntity.bookmarkEntity;
+
+@Repository
+public class BoardCustomRepositoryImpl implements BoardCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public BoardCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public List<BoardReadWithBookmarkResponse> findRecipesByQueryDslWithTitleAndContent(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable) {
+        List<BoardEntity> recipeList = jpaQueryFactory
+                .selectFrom(boardEntity)
+                .leftJoin(detailEntity).on(detailEntity.post.eq(boardEntity))
+                .where(
+                        eqKeyword(filteringRequest.getKeyword())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(sortPostList(pageable))
+                .fetch();
+
+        return recipeList.stream()
+                .map(board -> new BoardReadWithBookmarkResponse(board, checkBookmarkStatus(board, memberId)))
+                .toList();
+    }
+
+    @Override
+    public List<BoardReadWithBookmarkResponse> findRecipesByQueryDslWithTagAndIngredients(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable) {
+        List<BoardEntity> recipeList = jpaQueryFactory
+                .selectFrom(boardEntity)
+                .leftJoin(tagEntity).on(tagEntity.post.eq(boardEntity))
+                .leftJoin(ingredientEntity).on(ingredientEntity.post.eq(boardEntity))
+                .where(
+                        eqTag(filteringRequest.getTagNames()),
+                        eqIngredients(filteringRequest.getIngredients())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(sortPostList(pageable))
+                .fetch();
+
+        return recipeList.stream()
+                .map(board -> new BoardReadWithBookmarkResponse(board, checkBookmarkStatus(board, memberId)))
+                .toList();
+    }
+
+    // 북마크 상태 확인 메소드
+    private boolean checkBookmarkStatus(BoardEntity board, Long memberId) {
+        return jpaQueryFactory
+                .select(bookmarkEntity.status)
+                .from(bookmarkEntity)
+                .where(
+                        bookmarkEntity.post.eq(board),
+                        bookmarkEntity.member.id.eq(memberId),
+                        bookmarkEntity.status.isTrue()  // 북마크 상태가 true인 경우만 확인
+                )
+                .fetchOne() != null;
+    }
+
+    // 제목 혹은 내용으로 검색
+    private BooleanExpression eqKeyword(String keyword) {
+        if (keyword == null || keyword.isEmpty()) {
+            return null;
+        }
+        return boardEntity.title.contains(keyword)
+                .or(detailEntity.description.contains(keyword));
+    }
+
+    // 태그 필터링 ( 복수 ) 검색
+    private BooleanBuilder eqTag(List<String> tagNames){
+        if(tagNames == null || tagNames.isEmpty()){
+            return null;
+        }
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        for (String tagName : tagNames){
+            booleanBuilder.or(tagEntity.name.eq(tagName));
+        }
+
+        return booleanBuilder;
+    }
+
+    // 재료 필터링 ( 복수 ) 검색
+    private BooleanBuilder eqIngredients(List<String> ingredients){
+        if(ingredients == null || ingredients.isEmpty()){
+            return null;
+        }
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        for (String ingredient : ingredients){
+            booleanBuilder.or(ingredientEntity.name.eq(ingredient));
+        }
+
+        return booleanBuilder;
+    }
+
+    // 정렬
+    private OrderSpecifier<?> sortPostList(Pageable page){
+        //서비스에서 보내준 Pageable 객체에 정렬조건 null 값 체크
+        if (!page.getSort().isEmpty()) {
+            //정렬값이 들어 있으면 for 사용하여 값을 가져온다
+            for (Sort.Order order : page.getSort()) {
+                // 서비스에서 넣어준 DESC or ASC 를 가져온다.
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                // 서비스에서 넣어준 정렬 조건을 스위치 케이스 문을 활용하여 셋팅하여 준다.
+                switch (order.getProperty()){
+                    case "createdTime":
+                        return new OrderSpecifier(direction, boardEntity.createdTime);
+                    case "mostViewed":
+                        return new OrderSpecifier(direction, boardEntity.view_count);
+                }
+            }
+        }
+        return new OrderSpecifier(Order.DESC, boardEntity.modifiedTime);
+    }
+}

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
@@ -1,7 +1,6 @@
 package com.example.petstable.domain.board.repository;
 
 import com.example.petstable.domain.board.entity.BoardEntity;
-import com.example.petstable.domain.member.entity.SocialType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
+public interface BoardRepository extends JpaRepository<BoardEntity, Long>, BoardCustomRepository {
 
     @EntityGraph(attributePaths = {"details", "tags"})
     Optional<BoardEntity> findById(Long id);

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -3,10 +3,7 @@ package com.example.petstable.domain.board.service;
 import com.example.petstable.domain.board.dto.request.*;
 import com.example.petstable.domain.board.dto.response.*;
 import com.example.petstable.domain.board.entity.*;
-import com.example.petstable.domain.board.repository.BoardRepository;
-import com.example.petstable.domain.board.repository.DetailRepository;
-import com.example.petstable.domain.board.repository.IngredientRepository;
-import com.example.petstable.domain.board.repository.TagRepository;
+import com.example.petstable.domain.board.repository.*;
 import com.example.petstable.domain.bookmark.repository.BookmarkRepository;
 import com.example.petstable.domain.member.entity.MemberEntity;
 import com.example.petstable.domain.member.repository.MemberRepository;
@@ -142,6 +139,14 @@ public class BoardService {
         }
 
         return new BoardReadAllResponse(postResponses, pageResponse);
+    }
+
+    public List<BoardReadWithBookmarkResponse> findPostsByTitleAndContent(BoardFilteringRequest request, Pageable pageable, Long memberId) {
+        return boardRepository.findRecipesByQueryDslWithTitleAndContent(request, memberId, pageable);
+    }
+
+    public List<BoardReadWithBookmarkResponse> findPostsByTagAndIngredients(BoardFilteringRequest request, Pageable pageable, Long memberId) {
+        return boardRepository.findRecipesByQueryDslWithTagAndIngredients(request, memberId, pageable);
     }
 
     public BoardEntity validMemberAndPost(Long userId, Long boardId) {

--- a/src/main/java/com/example/petstable/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/example/petstable/global/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package com.example.petstable.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/example/petstable/repository/BoardCustomRepositoryImplTest.java
+++ b/src/test/java/com/example/petstable/repository/BoardCustomRepositoryImplTest.java
@@ -1,0 +1,143 @@
+package com.example.petstable.repository;
+
+import com.example.petstable.domain.board.dto.request.*;
+import com.example.petstable.domain.board.dto.response.BoardReadWithBookmarkResponse;
+import com.example.petstable.domain.board.entity.*;
+import com.example.petstable.domain.board.repository.*;
+import com.example.petstable.domain.member.entity.MemberEntity;
+import com.example.petstable.domain.member.entity.SocialType;
+import com.example.petstable.domain.member.repository.MemberRepository;
+import com.example.petstable.global.config.QueryDSLConfig;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+@SpringBootTest
+@Import({BoardCustomRepositoryImpl.class, QueryDSLConfig.class})
+@Transactional
+public class BoardCustomRepositoryImplTest {
+
+    @Autowired
+    private BoardCustomRepositoryImpl boardCustomRepositoryImpl;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @Test
+    @DisplayName("제목으로만 조회")
+    void searchTitle() {
+        // given
+        MemberEntity member = MemberEntity.builder()
+                .nickName("테스트유저231")
+                .socialType(SocialType.TEST)
+                .build();
+        memberRepository.save(member);
+
+        String expected = "검색 필터링 테스트 제목";
+        BoardEntity boardEntity = BoardEntity.builder()
+                .title(expected)
+                .details(null)
+                .tags(null)
+                .ingredients(null)
+                .build();
+        boardRepository.save(boardEntity);
+
+        BoardFilteringRequest requestOnlyTitle = BoardFilteringRequest.builder()
+                .keyword(expected)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdTime").descending());
+
+        // when
+        List<BoardReadWithBookmarkResponse> actual = boardCustomRepositoryImpl.findRecipesByQueryDslWithTitleAndContent(requestOnlyTitle, member.getId(), pageable);
+
+        // then
+        Assertions.assertThat(actual).isNotEmpty();
+        Assertions.assertThat(actual.get(0).getTitle()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("상세 내용, 태그, 재료 연관관계 테스트")
+    void testBoardDetailTagIngredientRelationships() {
+        // given
+        MemberEntity member = MemberEntity.builder()
+                .nickName("테스트유저")
+                .socialType(SocialType.TEST)
+                .build();
+        memberRepository.save(member);
+
+        // 태그 생성
+        TagEntity tag1 = TagEntity.builder()
+                .name("테스트 태그 1")
+                .build();
+
+        TagEntity tag2 = TagEntity.builder()
+                .name("테스트 태그 2")
+                .build();
+
+        // 재료 생성
+        IngredientEntity ingredient1 = IngredientEntity.builder()
+                .name("재료 1")
+                .build();
+
+        IngredientEntity ingredient2 = IngredientEntity.builder()
+                .name("재료 2")
+                .build();
+
+        List<TagEntity> tags = Arrays.asList(tag1, tag2);
+        List<IngredientEntity> ingredients = Arrays.asList(ingredient1, ingredient2);
+
+        tagRepository.saveAll(tags);
+        ingredientRepository.saveAll(ingredients);
+
+        // BoardEntity 생성
+        BoardEntity boardEntity = BoardEntity.builder()
+                .title("검증용 제목")
+                .tags(new ArrayList<>())
+                .ingredients(new ArrayList<>())
+                .build();
+
+        // 연관관계 추가
+        boardEntity.getTags().forEach(tag -> tag.getPost().addTags(List.of(tag)));
+        boardEntity.getIngredients().forEach(ingredient -> ingredient.getPost().addIngredient(List.of(ingredient)));
+
+        // 엔티티 저장
+        boardRepository.save(boardEntity);
+
+        tag1.setPost(boardEntity);
+        tag2.setPost(boardEntity);
+        ingredient1.setPost(boardEntity);
+        ingredient2.setPost(boardEntity);
+        tagRepository.saveAll(tags);
+        ingredientRepository.saveAll(ingredients);
+
+        // when
+        BoardFilteringRequest request = BoardFilteringRequest.builder()
+                .tagNames(List.of("테스트 태그 1", "테스트 태그 2"))
+                .ingredients(List.of("재료 1", "재료 2"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdTime").descending());
+
+        List<BoardReadWithBookmarkResponse> actual = boardCustomRepositoryImpl.findRecipesByQueryDslWithTagAndIngredients(request, member.getId(), pageable);
+
+        // then
+        Assertions.assertThat(actual).isNotEmpty();
+        Assertions.assertThat(actual.get(0).getTitle()).isEqualTo("검증용 제목");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 검색 필터링 기능 구현 #80 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/80)

## 📝작업 내용

> QueryDSL 를 활용하여 제목 혹은 내용, 해시태그로 조회하는 기능, 조회순/최신순으로 필터링 하는 기능을 추가하였습니다.