### PR TITLE
feat: 이미지 저장관련 로직 수정

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -75,7 +75,7 @@ public class BoardService {
 
         BoardEntity post = BoardEntity.builder()
                 .title(request.getTitle())
-                .thumbnail_url(awsS3Uploader.uploadImage(request.getThumbnail()))
+                .thumbnail_url(awsS3Uploader.uploadImage("recipe", request.getThumbnail()))
                 .build();
 
         member.addPost(post);
@@ -83,7 +83,7 @@ public class BoardService {
 
         List<DetailEntity> details = request.getDetails().stream()
                 .map(detailRequest -> {
-                    String imageUrl = awsS3Uploader.uploadImage(detailRequest.getImage());
+                    String imageUrl = awsS3Uploader.uploadImage("recipe", detailRequest.getImage());
                     String description = detailRequest.getDescription();
                     return DetailEntity.builder()
                             .image_url(imageUrl)
@@ -214,11 +214,11 @@ public class BoardService {
         String newDescription = request.getDescription();
 
         if (image != null && newDescription != null) { // 사진, 설명 변경
-            String newImageUrl = awsS3Uploader.uploadImage(image);
+            String newImageUrl = awsS3Uploader.uploadImage("recipe", image);
             detail.updateImageUrlAndDescription(newImageUrl, newDescription);
 
         } else if (image != null) { // 사진만 변경
-            String newImageUrl = awsS3Uploader.uploadImage(image);
+            String newImageUrl = awsS3Uploader.uploadImage("recipe", image);
             detail.updateImageUrl(newImageUrl);
 
         } else { // 설명만 변경

--- a/src/main/java/com/example/petstable/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/petstable/domain/member/service/MemberService.java
@@ -72,7 +72,7 @@ public class MemberService {
     public MemberProfileImageResponse registerProfileImage(Long memberId, MultipartFile multipartFile) {
 
         MemberEntity member = validateMember(memberId);
-        String imageUrl = awsS3Uploader.uploadImage(multipartFile);
+        String imageUrl = awsS3Uploader.uploadImage("member", multipartFile);
 
         member.updateProfileImage(imageUrl);
 
@@ -86,8 +86,9 @@ public class MemberService {
     public MemberProfileImageResponse deleteProfileImage(Long memberId) {
 
         MemberEntity member = validateMember(memberId);
-
+        String imageUrl = member.getImage_url();
         member.updateProfileImage(null);
+        awsS3Uploader.deleteImage("member", imageUrl);
 
         return MemberProfileImageResponse.builder()
                 .id(member.getId())

--- a/src/main/java/com/example/petstable/domain/pet/service/PetService.java
+++ b/src/main/java/com/example/petstable/domain/pet/service/PetService.java
@@ -116,7 +116,7 @@ public class PetService {
 
         PetEntity pet = validatePet(petId, memberId);
 
-        String imageUrl = awsS3Uploader.uploadImage(multipartFile);
+        String imageUrl = awsS3Uploader.uploadImage("pet", multipartFile);
 
         pet.updateImage(imageUrl);
 

--- a/src/main/java/com/example/petstable/global/support/AwsS3Uploader.java
+++ b/src/main/java/com/example/petstable/global/support/AwsS3Uploader.java
@@ -2,6 +2,7 @@ package com.example.petstable.global.support;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.petstable.global.exception.PetsTableException;
@@ -12,44 +13,90 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
-import static com.example.petstable.global.support.UploadMessage.FILE_INVALID_EMPTY;
+import static com.example.petstable.global.support.UploadMessage.*;
 
 @Component
 @RequiredArgsConstructor
 public class AwsS3Uploader {
 
-    private static final String S3_BUCKET_DIRECTORY_NAME = "static";
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp", "image/heic", "image/heif");
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L; // 최대 5MB
 
     private final AmazonS3 amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadImage(MultipartFile multipartFile) {
+    public String uploadImage(String directoryPath, MultipartFile multipartFile) {
+        String fileName = directoryPath + generateImageFileName(multipartFile);  // 이미지 파일 이름 생성
+        // 파일 유효성 검사
         checkInvalidUploadFile(multipartFile);
+        validateExtension(multipartFile);
+        validateFileSize(multipartFile);
 
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentType(multipartFile.getContentType());
         objectMetadata.setContentLength(multipartFile.getSize());
 
-        String originalFilename = multipartFile.getOriginalFilename();
-        String extension = originalFilename != null && originalFilename.contains(".")
-                ? originalFilename.substring(originalFilename.lastIndexOf("."))
-                : "";
-
-        String fileName = S3_BUCKET_DIRECTORY_NAME + "/" + UUID.randomUUID() + extension;
-
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
-            throw new IllegalStateException("S3 파일 업로드에 실패했습니다.");
+            throw new PetsTableException(FILE_UPLOAD_FAIL.getStatus(), FILE_UPLOAD_FAIL.getMessage(), 400);
         }
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
+    public void deleteImage(String directoryPath, String fileName) {
+        String fullPath = directoryPath + fileName; // 파일의 전체 경로
+        try {
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fullPath));
+        } catch (Exception e) {
+            throw new PetsTableException(FILE_DELETE_FAIL.getStatus(), FILE_DELETE_FAIL.getMessage(), 400);
+        }
+    }
+
+    // 이미지 파일 이름을 UUID 기반으로 생성
+    public String generateImageFileName(MultipartFile image) {
+        String extension = getExtension(Objects.requireNonNull(image.getContentType()));
+        if (extension == null) {
+            throw new PetsTableException(INVALID_IMAGE_TYPE.getStatus(), INVALID_IMAGE_TYPE.getMessage(), 400);
+        }
+        return "/" + UUID.randomUUID() + extension;
+    }
+
+    // 확장자에 맞는 파일 포맷 가져오기
+    private String getExtension(String contentType) {
+        return switch (contentType) {
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            case "image/heic" -> ".heic";
+            case "image/heif" -> ".heif";
+            default -> ".jpg";
+        };
+    }
+
+    // 이미지 파일 확장자 유효성 검사
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new PetsTableException(INVALID_IMAGE_TYPE.getStatus(), INVALID_IMAGE_TYPE.getMessage(), 400);
+        }
+    }
+
+    // 이미지 파일 크기 유효성 검사
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new PetsTableException(INVALID_IMAGE_SIZE.getStatus(), INVALID_IMAGE_SIZE.getMessage(), 400);
+        }
+    }
+
+    // 파일이 비어있거나 크기가 0인 경우 유효하지 않음
     private void checkInvalidUploadFile(MultipartFile multipartFile) {
         if (multipartFile.isEmpty() || multipartFile.getSize() == 0) {
             throw new PetsTableException(FILE_INVALID_EMPTY.getStatus(), FILE_INVALID_EMPTY.getMessage(), 400);

--- a/src/main/java/com/example/petstable/global/support/UploadMessage.java
+++ b/src/main/java/com/example/petstable/global/support/UploadMessage.java
@@ -10,6 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum UploadMessage implements ResponseMessage {
 
     FILE_UPLOAD_FAIL("이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_DELETE_FAIL("이미지 삭제에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    WRONG_IMAGE_URL("잘못된 이미지 URL 입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_IMAGE_TYPE("지원하지 않는 이미지 확장자 입니다", HttpStatus.BAD_REQUEST),
+    INVALID_IMAGE_SIZE("지원하지 않는 이미지 크기 입니다.", HttpStatus.BAD_REQUEST),
     FILE_INVALID_EMPTY("빈 파일은 업로드할 수 없습니다", HttpStatus.BAD_REQUEST);
 
     private final String message;

--- a/src/test/java/com/example/petstable/service/BoardServiceTest.java
+++ b/src/test/java/com/example/petstable/service/BoardServiceTest.java
@@ -97,9 +97,9 @@ public class BoardServiceTest {
         MockMultipartFile mockMultipartFile1 = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
         MockMultipartFile mockMultipartFile2 = new MockMultipartFile("test_img2", "test_img2.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img2.jpg"));
         MockMultipartFile mockMultipartFile3 = new MockMultipartFile("test_img3", "test_img3.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img3.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile1)).thenReturn("test_img.jpg");
-        when(awsS3Uploader.uploadImage(mockMultipartFile2)).thenReturn("test_img2.jpg");
-        when(awsS3Uploader.uploadImage(mockMultipartFile3)).thenReturn("test_img3.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile1)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile2)).thenReturn("test_img2.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile3)).thenReturn("test_img3.jpg");
 
         TagRequest tagRequest = TagRequest.builder().tagType("기능별").tagName("모질개선").build();
         TagRequest tagRequest2 = TagRequest.builder().tagType("기능별").tagName("다이어트").build();
@@ -172,7 +172,7 @@ public class BoardServiceTest {
         memberRepository.save(member);
 
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile)).thenReturn("test_img.jpg");
 
         DescriptionRequest descriptionRequest = new DescriptionRequest("설명");
         TagRequest tagRequest = TagRequest.builder().tagType("기능별").tagName("모질개선").build();
@@ -214,7 +214,7 @@ public class BoardServiceTest {
         memberRepository.save(member);
 
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile)).thenReturn("test_img.jpg");
 
         DescriptionRequest descriptionRequest = new DescriptionRequest("설명");
         TagRequest tagRequest = TagRequest.builder().tagType("기능별").tagName("모질개선").build();
@@ -339,7 +339,7 @@ public class BoardServiceTest {
         detail.setPost(post);
 
         MockMultipartFile expected = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(expected)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", expected)).thenReturn("test_img.jpg");
 
         // when
         boardService.updatePostDetail(member.getId(), post.getId(), detail.getId(), null, expected);
@@ -430,7 +430,7 @@ public class BoardServiceTest {
         detail.setPost(post);
 
         MockMultipartFile expected = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(expected)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", expected)).thenReturn("test_img.jpg");
 
         // when
         DetailUpdateRequest request = DetailUpdateRequest.builder()
@@ -543,7 +543,7 @@ public class BoardServiceTest {
         memberRepository.save(member);
 
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile)).thenReturn("test_img.jpg");
 
         IngredientRequest ingredientRequest = IngredientRequest.builder()
                 .name("당근")

--- a/src/test/java/com/example/petstable/service/MemberServiceTest.java
+++ b/src/test/java/com/example/petstable/service/MemberServiceTest.java
@@ -150,7 +150,7 @@ public class MemberServiceTest {
         memberRepository.save(member);
 
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile)).thenReturn("test_img.jpg");
 
         // when
         memberService.registerProfileImage(member.getId(), mockMultipartFile);

--- a/src/test/java/com/example/petstable/service/PetServiceTest.java
+++ b/src/test/java/com/example/petstable/service/PetServiceTest.java
@@ -232,7 +232,7 @@ public class PetServiceTest {
         petRepository.save(pet);
 
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg", new FileInputStream("src/test/resources/images/test_img.jpg"));
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        when(awsS3Uploader.uploadImage("test", mockMultipartFile)).thenReturn("test_img.jpg");
 
         // when
         petService.registerPetImage(member.getId(), pet.getId(), mockMultipartFile);


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 이미지 저장관련 로직 수정 #85 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/85)

## 📝작업 내용
 이미지 삭제 로직 추가
 확장자 및 크기 검증 로직 추가
 확장자에 따른 저장 로직 변경