### PR TITLE
feat: CDN 도입 및 이미지 리사이징 구현

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
@@ -117,6 +117,56 @@ public interface BoardApi {
             @Parameter(hidden = true) @LoginUserId Long memberId
     );
 
+    @Operation(summary = "레시피 목록 전체 조회 API", description = "레시피 목록을 전체 조회하는 API 입니다.", responses = {
+            @ApiResponse(responseCode = "200", content = @Content(
+                    schema = @Schema(implementation = BoardReadAllResponse.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "recipes": [
+                        {
+                          "id": 1,
+                          "title": "말티즈를 위한 닭죽 만들기",
+                          "imageUrl": "https://example.com/image1.jpg",
+                          "bookmarkStatus": true,
+                          "tagName": [
+                            "모질개선",
+                            "저알러지"
+                          ]
+                        },
+                        {
+                          "id": 2,
+                          "title": "포메라니안을 위한 건강 수프",
+                          "imageUrl": "https://example.com/image2.jpg",
+                          "bookmarkStatus": false,
+                          "tagName": [
+                            "체중조절",
+                            "영양강화"
+                          ]
+                        }
+                      ],
+                      "pageResponse": {
+                        "totalPages": 10,
+                        "currentPage": 1,
+                        "totalElements": 100,
+                        "isPageLast": false,
+                        "size": 10,
+                        "numberOfElements": 10,
+                        "isPageFirst": true,
+                        "isEmpty": false
+                      }
+                    }
+                    """)
+            ),
+                    description = "레시피 목록 조회에 성공하였습니다."
+            ),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 올바르지 않습니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+    })
+    PetsTableApiResponse<BoardReadAllResponse> readAllPostV2(
+            Pageable pageable,
+            @Parameter(hidden = true) @LoginUserId Long memberId
+    );
+
     @Operation(summary = "특정 조건으로 검색 및 정렬된 레시피 게시글 조회 API",
             description = "제목 또는 내용 혹은 태그 이름과 재료로 레시피 게시글을 검색합니다.\n 인기순/최신순 으로 정렬하기 위해선 sort 에 createdTime / mostViewed 넣으면 됩니다.",
             responses = {
@@ -273,6 +323,61 @@ public interface BoardApi {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
     })
     PetsTableApiResponse<BoardDetailReadResponse> getPostDetail(
+            @Parameter(hidden = true) @LoginUserId Long memberId,
+            @PathVariable("boardId") Long boardId
+    );
+
+    @Operation(summary = "레시피 상세 조회 API", description = "특정 레시피의 상세 정보를 조회하는 API입니다.",
+            parameters = @Parameter(name = "boardId", description = "레시피 id", required = true),
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(
+                            schema = @Schema(implementation = BoardDetailReadResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 1,
+                      "title": "말티즈를 위한 닭죽 만들기",
+                      "viewCount": 1041,
+                      "bookmarkStatus": true,
+                      "details": [
+                        {
+                          "image_url": "https://example.com/detail-image1.jpg",
+                          "description": "1단계: 물 500mL를 끓인다."
+                        },
+                        {
+                          "image_url": "https://example.com/detail-image2.jpg",
+                          "description": "2단계: 닭고기를 넣고 20분간 끓인다."
+                        }
+                      ],
+                      "tags": [
+                        {
+                          "tagType": "기능별",
+                          "tagName": "모질개선"
+                        },
+                        {
+                          "tagType": "기능별",
+                          "tagName": "저알러지"
+                        }
+                      ],
+                      "ingredients": [
+                        {
+                          "name": "닭고기",
+                          "weight": "200g"
+                        },
+                        {
+                          "name": "당근",
+                          "weight": "50g"
+                        }
+                      ]
+                    }
+                    """)
+                    ),
+                            description = "레시피 상세 조회에 성공하였습니다."
+                    ),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "해당 레시피를 찾을 수 없습니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+            })
+    PetsTableApiResponse<BoardDetailReadResponse> getPostDetailV2(
             @Parameter(hidden = true) @LoginUserId Long memberId,
             @PathVariable("boardId") Long boardId
     );

--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -37,6 +37,12 @@ public class BoardController implements BoardApi {
         return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
     }
 
+    @GetMapping("/v2")
+    public PetsTableApiResponse<BoardReadAllResponse> readAllPostV2(Pageable pageable, @LoginUserId Long memberId) {
+        BoardReadAllResponse response = boardService.getAllPostV2(pageable, memberId);
+        return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
+    }
+
     @GetMapping("/search")
     public PetsTableApiResponse<List<BoardReadResponse>> readPostsByFiltering(
             @RequestParam(value = "keyword", required = false) String keyword,
@@ -64,6 +70,12 @@ public class BoardController implements BoardApi {
 
         BoardDetailReadResponse response = boardService.findDetailByBoardId(memberId, boardId);
 
+        return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
+    }
+
+    @GetMapping("/v2/{boardId}")
+    public PetsTableApiResponse<BoardDetailReadResponse> getPostDetailV2(@LoginUserId Long memberId, @PathVariable("boardId") Long boardId) {
+        BoardDetailReadResponse response = boardService.findDetailByBoardIdV2(memberId, boardId);
         return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
     }
 

--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
@@ -24,10 +24,9 @@ public class BoardDetailReadResponse {
     private List<IngredientResponse> ingredients;
 
     public static BoardDetailReadResponse from(BoardEntity boardEntity, boolean status) {
-
         List<DetailResponse> details = boardEntity.getDetails().stream()
                 .map(detail -> DetailResponse.builder()
-                        .image_url(detail.getImage_url())
+                        .image_url(detail.getImage_url() + "?size=step")
                         .description(detail.getDescription())
                         .build())
                 .toList();
@@ -49,7 +48,7 @@ public class BoardDetailReadResponse {
         return BoardDetailReadResponse.builder()
                 .id(boardEntity.getId())
                 .title(boardEntity.getTitle())
-                .thumbnail(boardEntity.getThumbnail_url())
+                .thumbnail(boardEntity.getThumbnail_url() + "?size=thumbnail")
                 .author(boardEntity.getMember().getNickName())
                 .viewCount(boardEntity.getView_count())
                 .createdAt(boardEntity.getCreatedTime())

--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardReadResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardReadResponse.java
@@ -23,7 +23,7 @@ public class BoardReadResponse {
     public BoardReadResponse(BoardEntity post) {
         this.id = post.getId();
         this.title = post.getTitle();
-        this.imageUrl = post.getThumbnail_url();
+        this.imageUrl = post.getThumbnail_url() + "?size=preview";
         this.author = post.getMember().getNickName();
         if (post.getTags() != null) {
             this.tagName = post.getTags()
@@ -42,7 +42,7 @@ public class BoardReadResponse {
     public BoardReadResponse(BoardEntity post, boolean status) {
         this.id = post.getId();
         this.title = post.getTitle();
-        this.imageUrl = post.getThumbnail_url();
+        this.imageUrl = post.getThumbnail_url() + "?size=preview";
         this.bookmarkStatus = status;
         this.author = getAuthor();
         if (post.getTags() != null) {

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
@@ -1,6 +1,8 @@
 package com.example.petstable.domain.board.repository;
 
 import com.example.petstable.domain.board.entity.BoardEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +17,9 @@ public interface BoardRepository extends JpaRepository<BoardEntity, Long>, Board
     Optional<BoardEntity> findById(Long id);
 
     Optional<BoardEntity> findByTitle(String title);
+
+    @Query("SELECT b FROM BoardEntity b JOIN FETCH b.member")
+    Page<BoardEntity> findAllWithMembers(Pageable pageable);
 
     @Query("select b from BoardEntity b where b.member.id = :memberId")
     List<BoardEntity> findAllByMemberId(@Param("memberId") Long memberId);

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -8,6 +8,7 @@ import com.example.petstable.domain.bookmark.repository.BookmarkRepository;
 import com.example.petstable.domain.member.entity.MemberEntity;
 import com.example.petstable.domain.member.repository.MemberRepository;
 import com.example.petstable.domain.point.service.PointService;
+import com.example.petstable.global.config.AmazonConfig;
 import com.example.petstable.global.exception.PetsTableException;
 import com.example.petstable.global.support.AwsS3Uploader;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ public class BoardService {
     private final TagRepository tagRepository;
     private final IngredientRepository ingredientRepository;
     private final PointService pointService;
+    private final AmazonConfig amazonConfig;
 
     @Transactional
     public BoardPostResponse writePost(Long memberId, BoardPostRequest request, MultipartFile thumbnail, List<MultipartFile> images) {
@@ -176,6 +178,24 @@ public class BoardService {
         return new BoardReadAllResponse(postResponses, pageResponse);
     }
 
+    public BoardReadAllResponse getAllPostV2(Pageable pageable, Long memberId) {
+        Page<BoardEntity> postPage = boardRepository.findAllWithMembers(pageable);
+        List<BoardReadResponse> postResponses = postPage.stream()
+                .map(post -> {
+                    boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, post.getId());
+                    // 만약 기존에 저장된 이미지의 url이 s3 도메인이라면 cloudfront 도메인으로 변경
+                    String thumbnailUrl = post.getThumbnail_url();
+                    post.setThumbnail_url(convertThumbnailUrlToCloudFront(thumbnailUrl));
+                    return new BoardReadResponse(post, isBookmarked);
+                })
+                .collect(Collectors.toList());
+        PageResponse pageResponse = new PageResponse(postPage);
+        if (postResponses.isEmpty()) {
+            throw new PetsTableException(RECIPE_IS_EMPTY.getStatus(), RECIPE_IS_EMPTY.getMessage(), 204);
+        }
+        return new BoardReadAllResponse(postResponses, pageResponse);
+    }
+
     public List<BoardReadResponse> findPostsByTitleAndContent(BoardFilteringRequest request, Pageable pageable, Long memberId) {
         return boardRepository.findRecipesByQueryDslWithTitleAndContent(request, memberId, pageable);
     }
@@ -204,6 +224,32 @@ public class BoardService {
         boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, boardId);
 
         return BoardDetailReadResponse.from(boardEntity, isBookmarked);
+    }
+
+    @Transactional
+    public BoardDetailReadResponse findDetailByBoardIdV2(Long memberId, Long boardId) {
+        BoardEntity boardEntity = boardRepository.findById(boardId)
+                .orElseThrow(() -> new PetsTableException(POST_NOT_FOUND.getStatus(), POST_NOT_FOUND.getMessage(), 404));
+        boardEntity.increaseViewCount(); // 조회수 증가
+        String updatedThumbnailUrl = updateThumbnailUrlIfNeeded(boardEntity.getThumbnail_url());
+        boardEntity.setThumbnail_url(updatedThumbnailUrl);
+        updateDetailImageUrls(boardEntity);
+        boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, boardId);
+        return BoardDetailReadResponse.from(boardEntity, isBookmarked);
+    }
+
+    private void updateDetailImageUrls(BoardEntity boardEntity) {
+        for (DetailEntity detail : boardEntity.getDetails()) {
+            String updatedImageUrl = updateThumbnailUrlIfNeeded(detail.getImage_url());
+            detail.updateImageUrl(updatedImageUrl); // 변경된 이미지 URL을 설정
+        }
+    }
+
+    private String updateThumbnailUrlIfNeeded(String url) {
+        if (url.startsWith(amazonConfig.getS3Uri())) {
+            return url.replace(amazonConfig.getS3Uri(), amazonConfig.getCloudfrontUri());
+        }
+        return url;
     }
 
     @Transactional
@@ -296,11 +342,22 @@ public class BoardService {
         }
         List<BoardReadResponse> recipes = myRecipe
                 .stream()
-                .map(recipe -> new BoardReadResponse(recipe))
+                .map(recipe -> {
+                    String cloudfrontUrl = convertThumbnailUrlToCloudFront(recipe.getThumbnail_url());
+                    recipe.setThumbnail_url(cloudfrontUrl);
+                    return new BoardReadResponse(recipe);
+                })
                 .toList();
         return BoardResponse.builder()
                 .count(recipes.size())
                 .recipes(recipes)
                 .build();
+    }
+
+    private String convertThumbnailUrlToCloudFront(String image) {
+        if (image.startsWith(amazonConfig.getS3Uri())) {
+            return image.replace(amazonConfig.getS3Uri(), amazonConfig.getCloudfrontUri());
+        }
+        return image;
     }
 }

--- a/src/main/java/com/example/petstable/global/config/AmazonConfig.java
+++ b/src/main/java/com/example/petstable/global/config/AmazonConfig.java
@@ -5,12 +5,14 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class S3Config {
+@Getter
+public class AmazonConfig {
 
     @Value("${cloud.aws.s3.credentials.accessKey}")
     private String accessKey;
@@ -20,6 +22,15 @@ public class S3Config {
 
     @Value("${cloud.aws.s3.region.static}")
     private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.uri}")
+    private String s3Uri;
+
+    @Value("${cloud.aws.cloudfront.uri}")
+    private String cloudfrontUri;
 
     @Bean
     public AmazonS3 amazonS3() {
@@ -31,5 +42,4 @@ public class S3Config {
                 .withRegion(region)
                 .build();
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: CloudFront 도입 및 이미지 리사이징 구현 #97 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/97)

## 📝작업 내용

1. 업로드 시 CloudFront 도메인으로 저장되도록 추 및 기존 S3 도메인으로 저장된 경우 CloudFront 링크로 저장되도록 변환 로직 추가
2. 레시피 목록, 상세 조회, 나의 레시피 조회 시 레시피 이미지 관련 서비스 로직을 리사이지을 이용한 V2 버전으로 구현