### PR TITLE
feat: 레시피 조회 캐시 적용

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardApi.java
@@ -157,10 +157,20 @@ public interface BoardApi {
             @Parameter(hidden = true) @LoginUserId Long memberId
     );
 
-    @Operation(summary = "레시피 목록 전체 조회 API V2", description = "레시피 목록을 전체 조회하는 API 입니다.", responses = {
-            @ApiResponse(responseCode = "200", content = @Content(
-                    schema = @Schema(implementation = BoardReadAllResponse.class),
-                    examples = @ExampleObject(value = """
+    @Operation(summary = "레시피 목록 전체 조회 API V2", description = "정렬된 레시피 목록을 전체 조회하는 API 입니다.",
+            parameters = {
+                    @Parameter(
+                            name = "sortBy",
+                            description = "레시피를 인기순/최신순 으로 조회하는 API입니다..",
+                            required = true,
+                            schema = @Schema(type = "string", allowableValues = {"POPULAR", "LATEST"}),
+                            example = "POPULAR"
+                    )
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(
+                            schema = @Schema(implementation = BoardReadAllResponse.class),
+                            examples = @ExampleObject(value = """
                     {
                       "recipes": [
                         {
@@ -196,15 +206,16 @@ public interface BoardApi {
                       }
                     }
                     """)
-            ),
-                    description = "레시피 목록 조회에 성공하였습니다."
-            ),
-            @ApiResponse(responseCode = "401", description = "액세스 토큰이 올바르지 않습니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
-    })
+                    ),
+                            description = "레시피 목록 조회에 성공하였습니다."
+                    ),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+            })
     PetsTableApiResponse<BoardReadAllResponse> readAllPostV2(
             Pageable pageable,
-            @Parameter(hidden = true) @LoginUserId Long memberId
+            @Parameter(hidden = true) @LoginUserId Long memberId,
+            @RequestParam String sortBy
     );
 
     @Operation(summary = "특정 조건으로 검색 및 정렬된 레시피 게시글 조회 API",

--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -43,9 +43,7 @@ public class BoardController implements BoardApi {
 
     @GetMapping
     public PetsTableApiResponse<BoardReadAllResponse> readAllPost(Pageable pageable, @LoginUserId Long memberId) {
-
         BoardReadAllResponse response = boardService.getAllPost(pageable, memberId);
-
         return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
     }
 
@@ -79,9 +77,7 @@ public class BoardController implements BoardApi {
 
     @GetMapping("/{boardId}")
     public PetsTableApiResponse<BoardDetailReadResponse> getPostDetail(@LoginUserId Long memberId, @PathVariable("boardId") Long boardId) {
-
         BoardDetailReadResponse response = boardService.findDetailByBoardId(memberId, boardId);
-
         return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
     }
 
@@ -93,33 +89,25 @@ public class BoardController implements BoardApi {
 
     @PatchMapping(value = "/{boardId}/title")
     public ResponseEntity<String> updatePostTitle(@LoginUserId Long userId, @PathVariable("boardId") Long boardId, @RequestBody BoardUpdateTitleRequest request) {
-
         boardService.updatePostTitle(userId, boardId, request);
-
         return ResponseEntity.ok(UPDATE_SUCCESS.getMessage());
     }
 
     @PostMapping(value = "/{boardId}/tag/{tagId}")
     public ResponseEntity<String> updatePostTag(@LoginUserId Long userId, @PathVariable("boardId") Long boardId, @RequestBody List<BoardUpdateTagRequest> request) {
-
         boardService.updatePostTags(userId, boardId, request);
-
         return ResponseEntity.ok(UPDATE_SUCCESS.getMessage());
     }
 
     @PatchMapping(value = "/{boardId}/details/{detailId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> updatePostDetail(@LoginUserId Long userId, @PathVariable("boardId") Long boardId, @PathVariable("detailId") Long detailId, @RequestPart(name = "request", required = false) DetailUpdateRequest request, @RequestPart(name = "image", required = false) MultipartFile image) {
-
         boardService.updatePostDetail(userId, boardId, detailId, request, image);
-
         return ResponseEntity.ok(UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping(value = "/{boardId}/details/{detailId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public PetsTableApiResponse<DetailResponse> deletePostDetail (@LoginUserId Long userId, @PathVariable("boardId") Long boardId, @PathVariable("detailId") Long detailId) {
-
         DetailResponse response = boardService.deletePostDetail(userId, boardId, detailId);
-
         return PetsTableApiResponse.createResponse(response, DELETE_DETAIL_SUCCESS);
     }
 }

--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -50,8 +50,8 @@ public class BoardController implements BoardApi {
     }
 
     @GetMapping("/v2")
-    public PetsTableApiResponse<BoardReadAllResponse> readAllPostV2(Pageable pageable, @LoginUserId Long memberId) {
-        BoardReadAllResponse response = boardService.getAllPostV2(pageable, memberId);
+    public PetsTableApiResponse<BoardReadAllResponse> readAllPostV2(Pageable pageable, @LoginUserId Long memberId, @RequestParam("sortBy") String sortBy) {
+        BoardReadAllResponse response = boardService.getAllPostV2(pageable, memberId, sortBy);
         return PetsTableApiResponse.createResponse(response, GET_POST_ALL_SUCCESS);
     }
 

--- a/src/main/java/com/example/petstable/domain/board/message/BoardMessage.java
+++ b/src/main/java/com/example/petstable/domain/board/message/BoardMessage.java
@@ -16,6 +16,7 @@ public enum BoardMessage implements ResponseMessage {
     GET_MY_RECIPE_COUNT("나의 레시피 조회 성공", HttpStatus.OK),
     GET_PRESIGNED_URL_SUCCESS("Presigned Url 가져오기 성공", HttpStatus.OK),
     MY_RECIPE_NOT_FOUND("나의 레시피가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    SORT_TYPE_NOT_FOUND("정렬 타입을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     WRITE_SUCCESS("레시피 작성 성공", HttpStatus.OK),
     UPDATE_SUCCESS("레시피 수정 성공", HttpStatus.OK),
     POST_NOT_UPDATED("변경된 내용이 없습니다.",  HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
@@ -29,4 +29,9 @@ public interface BoardRepository extends JpaRepository<BoardEntity, Long>, Board
 
     @Query("select m.id from BoardEntity m where m.title = :title")
     Long findIdByTitle(@Param("title") String title);
+
+    @Query("SELECT b from BoardEntity  b ORDER BY b.view_count DESC")
+    Page<BoardEntity> findTopRecipeByViews(Pageable pageable);
+    @Query("SELECT b FROM BoardEntity b ORDER BY b.createdTime DESC")
+    Page<BoardEntity> findTopRecipeByCreatedTime(Pageable pageable);
 }

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -204,8 +204,23 @@ public class BoardService {
         return new BoardReadAllResponse(postResponses, pageResponse);
     }
 
-    public BoardReadAllResponse getAllPostV2(Pageable pageable, Long memberId) {
-        Page<BoardEntity> postPage = boardRepository.findAllWithMembers(pageable);
+    private Page<BoardEntity> getRecipeSortedByLikes(Pageable pageable) {
+        return boardRepository.findTopRecipeByViews(pageable);
+    }
+
+    private Page<BoardEntity> getCoursesSortedByLatest(Pageable pageable) {
+        return boardRepository.findTopRecipeByCreatedTime(pageable);
+    }
+
+    public BoardReadAllResponse getAllPostV2(Pageable pageable, Long memberId, String sortBy) {
+        Page<BoardEntity> postPage;
+        if (sortBy.equalsIgnoreCase("POPULAR")) {
+            postPage = getRecipeSortedByLikes(pageable);
+        } else if (sortBy.equalsIgnoreCase("LATEST")) {
+            postPage = getCoursesSortedByLatest(pageable);
+        } else {
+            throw new PetsTableException(SORT_TYPE_NOT_FOUND.getStatus(), SORT_TYPE_NOT_FOUND.getMessage(), 404);
+        }
         List<BoardReadResponse> postResponses = postPage.stream()
                 .map(post -> {
                     boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, post.getId());


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 레시피 조회 캐시 적용 #109 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/109)

## 📝작업 내용
- cache Config 구현
- https://github.com/Graduate-PetsTable/PetsTable-backend/blob/b3bd2e9035cad991edb0589bdd8d55d7cdb043de/src/main/java/com/example/petstable/global/config/RedisClusterConfig.java#L112-L126

- 레시피 목록 전체 조회 V2 에 인기순 / 최신순 정렬조건을 추가하였습니다.
- https://github.com/Graduate-PetsTable/PetsTable-backend/blob/237b771fc97419c6a231e2dc3238ee6fecb8d2dc/src/main/java/com/example/petstable/domain/board/service/BoardService.java#L205-L213

- 메서드 레벨에서 캐시 적용
```java
@Cacheable(value = "recipe", key = "#sortBy + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
    public BoardReadAllResponse getAllPostV2(Pageable pageable, Long memberId, String sortBy) {
        Page<BoardEntity> postPage;
        if (sortBy.equalsIgnoreCase("POPULAR")) {
            postPage = getRecipeSortedByLikes(pageable);
        } else if (sortBy.equalsIgnoreCase("LATEST")) {
            postPage = getCoursesSortedByLatest(pageable);
        } else {
            throw new PetsTableException(SORT_TYPE_NOT_FOUND.getStatus(), SORT_TYPE_NOT_FOUND.getMessage(), 404);
        }
``` 

- DB 에 등록된 데이터와 Redis 에 등록된 캐시 데이터가 불일치 할 수 있기 때문에 CacheEvict 를 통해 캐시 초기화 ( 레시피 관련 데이터가 변경될 때 )
```java
@Caching(evict = {
            @CacheEvict(value = "recipe", allEntries = true),
            @CacheEvict(value = "myRecipe", key = "#memberId")
    })
```