### PR TITLE
feat: 조회수 관련 로직 Redis로 처리

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.example.petstable.domain.board.controller;
 import com.example.petstable.domain.board.dto.request.*;
 import com.example.petstable.domain.board.dto.response.*;
 import com.example.petstable.domain.board.service.BoardService;
+import com.example.petstable.domain.board.service.RecipeViewCntService;
 import com.example.petstable.global.auth.LoginUserId;
 import com.example.petstable.global.exception.PetsTableApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,8 @@ import static com.example.petstable.domain.board.message.BoardMessage.*;
 @RequestMapping("/recipe")
 @RequiredArgsConstructor
 public class BoardController implements BoardApi {
-
     private final BoardService boardService;
+    private final RecipeViewCntService recipeViewCntService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public PetsTableApiResponse<BoardPostResponse> createPost(@LoginUserId Long memberId, @RequestPart(value = "request", required = false) BoardPostRequest request, @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail, @RequestPart(value = "images", required = false) List<MultipartFile> images) {
@@ -77,6 +78,7 @@ public class BoardController implements BoardApi {
 
     @GetMapping("/{boardId}")
     public PetsTableApiResponse<BoardDetailReadResponse> getPostDetail(@LoginUserId Long memberId, @PathVariable("boardId") Long boardId) {
+        recipeViewCntService.incrementViewCount(boardId);
         BoardDetailReadResponse response = boardService.findDetailByBoardId(memberId, boardId);
         return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
     }

--- a/src/main/java/com/example/petstable/domain/board/entity/BoardEntity.java
+++ b/src/main/java/com/example/petstable/domain/board/entity/BoardEntity.java
@@ -32,7 +32,7 @@ public class BoardEntity extends BaseTimeEntity {
     private String thumbnail_url; // 썸네일 ( 완성 사진 )
     private int reportCount; // 신고 횟수
 
-    private int view_count; // 조회수
+    private int view_count = 0; // 조회수
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
@@ -149,12 +149,6 @@ public class BoardEntity extends BaseTimeEntity {
             this.tags.clear();
         }
     }
-
-    // 조회수 증가
-    public void increaseViewCount() {
-        this.view_count += 1;
-    }
-
     public void updateTitle(String newTitle) {
         this.title = newTitle;
     }

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepository.java
@@ -10,4 +10,5 @@ public interface BoardCustomRepository {
 
     List<BoardReadResponse> findRecipesByQueryDslWithTitleAndContent(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable);
     List<BoardReadResponse> findRecipesByQueryDslWithTagAndIngredients(BoardFilteringRequest filteringRequest, Long memberId, Pageable pageable);
+    void addViewCntFromRedis(Long postId, int addCnt);
 }

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepositoryImpl.java
@@ -138,4 +138,13 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
         }
         return new OrderSpecifier(Order.DESC, boardEntity.modifiedTime);
     }
+
+    @Override
+    public void addViewCntFromRedis(Long postId, int addCnt) {
+        jpaQueryFactory
+                .update(boardEntity)
+                .set(boardEntity.view_count, addCnt)
+                .where(boardEntity.id.eq(postId))
+                .execute();
+    }
 }

--- a/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/petstable/domain/board/repository/BoardRepository.java
@@ -34,4 +34,6 @@ public interface BoardRepository extends JpaRepository<BoardEntity, Long>, Board
     Page<BoardEntity> findTopRecipeByViews(Pageable pageable);
     @Query("SELECT b FROM BoardEntity b ORDER BY b.createdTime DESC")
     Page<BoardEntity> findTopRecipeByCreatedTime(Pageable pageable);
+    @Query("SELECT b.view_count FROM BoardEntity b WHERE b.id = :postId")
+    int findViewCntByPostId(Long postId);
 }

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -246,7 +246,6 @@ public class BoardService {
     public BoardDetailReadResponse findDetailByBoardId(Long memberId, Long boardId) {
         BoardEntity boardEntity = boardRepository.findById(boardId)
                 .orElseThrow(() -> new PetsTableException(POST_NOT_FOUND.getStatus(), POST_NOT_FOUND.getMessage(), 404));
-        boardEntity.increaseViewCount();
         boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, boardId);
         return BoardDetailReadResponse.from(boardEntity, isBookmarked, amazonConfig);
     }

--- a/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
@@ -35,7 +35,7 @@ public class RecipeViewCntService {
         log.info("value:{}",valueOperations.get(key));
     }
 
-    @Scheduled(cron = "0 0/15 * * * ?") // 3분에 한 번씩 조회수 갱신
+    @Scheduled(cron = "0 0/15 * * * ?") // 15분에 한 번씩 조회수 갱신
     public void deleteViewCntCacheFromRedis() {
         ScanOptions scanOptions = ScanOptions.scanOptions().match(KEY_PREFIX + "*").count(100).build(); // 100개
         Cursor<byte[]> keys = redisTemplateForCluster.getConnectionFactory()

--- a/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
@@ -1,0 +1,58 @@
+package com.example.petstable.domain.board.service;
+
+import com.example.petstable.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+
+public class RecipeViewCntService {
+
+    private final RedisTemplate<String, String> redisTemplateForCluster;
+    private static final String KEY_PREFIX = "recipe-views";
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public void incrementViewCount(Long postId) {
+        String key = KEY_PREFIX + ":" + postId;
+        ValueOperations<String, String> valueOperations = redisTemplateForCluster.opsForValue();
+        if (valueOperations.get(key) == null) {
+            valueOperations.set(key, String.valueOf(boardRepository.findViewCntByPostId(postId)), Duration.ofMinutes(5));
+        }
+        valueOperations.increment(key);
+        log.info("value:{}",valueOperations.get(key));
+    }
+
+    @Scheduled(cron = "0 0/15 * * * ?") // 3분에 한 번씩 조회수 갱신
+    public void deleteViewCntCacheFromRedis() {
+        ScanOptions scanOptions = ScanOptions.scanOptions().match(KEY_PREFIX + "*").count(100).build(); // 100개
+        Cursor<byte[]> keys = redisTemplateForCluster.getConnectionFactory()
+                .getConnection()
+                .scan(scanOptions);
+        while (keys.hasNext()) {
+            String data = Arrays.toString(keys.next());
+            Long postId = Long.parseLong(data.split(":")[1]);
+            String value = redisTemplateForCluster.opsForValue().get(data);
+            if(value != null) {
+                int viewCnt = Integer.parseInt(value);
+                boardRepository.addViewCntFromRedis(postId, viewCnt); // RDB에 반영
+                redisTemplateForCluster.delete(data); // Redis 키 삭제
+                log.info("Synced and deleted Redis key: {}", data);
+            } else {
+                log.info("No data found for key: {}", data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat: 조회수 관련 로직 Redis 로 처리하도록 변경 #110 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/110)

## 📝작업 내용

- 15분 간격으로 Redis에 존재하는 조회수 데이터를 RDB로 갱신할 수 있도록 로직 추가

- https://github.com/Graduate-PetsTable/PetsTable-backend/blob/0dd6b939ec3fca99ca0eca024672b030a93c0050/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java#L38-L57

  - Redis Keys 를 통해 조회 시 O(N)으로 모든 키를 한 번에 가져오기 때문에 싱글스레드로 동작하는 Redis에선 지연이라는 문제를 야기할 수 있기 때문에 SCAN 을 사용하여 지연 문제를 최소화 하였음.
  - **ScanOptions** : SCAN 명령어의 동작 방식
  - **Cursor** : SCAN 명령어의 결과를 반복적으로 탐색하는 데 사용되는 인터페이스
  - https://github.com/Graduate-PetsTable/PetsTable-backend/blob/0dd6b939ec3fca99ca0eca024672b030a93c0050/src/main/java/com/example/petstable/domain/board/repository/BoardCustomRepositoryImpl.java#L142-L149
    - 15분 간격으로 해당 메서드를 통해 RDB로 조회수 데이터를 업데이트
    - 기존에는 더티체킹으로 인해 100만번의 요청이 들어올 경우 100만번의 쿼리가 발생하지만 Redis 도입을 통해 96번의 요청만으로 조회수를 처리할 수 있게 되었습니다.

- https://github.com/Graduate-PetsTable/PetsTable-backend/blob/0dd6b939ec3fca99ca0eca024672b030a93c0050/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java#L27-L36
  - 원자적으로 동작하는 increment 를 사용하여 동시성 문제가 발생하지 않도록 하였습니다.