### PR TITLE
fix: byte 배열 문자열 변환 오류 수정

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
@@ -42,7 +42,7 @@ public class RecipeViewCntService {
                 .getConnection()
                 .scan(scanOptions);
         while (keys.hasNext()) {
-            String data = Arrays.toString(keys.next());
+            String data = new String(keys.next());
             Long postId = Long.parseLong(data.split(":")[1]);
             String value = redisTemplateForCluster.opsForValue().get(data);
             if(value != null) {


### PR DESCRIPTION
## 🐞 Bug Report

### 🔍 문제 설명
- 15분 간격으로 조회수 데이터를 RDB로 업데이트 하는 과정에서 scan으로 반환된 keys 값이 올바르게 반환되지 않고 `Index 1 out of bounds for length 1` 에러가 발생했습니다.

### 📝작업 내용

- 기존 로직
   ```java
  String data = Arrays.toString(keys.next());
  ```
  - Arrays.toString() 의 동작을 살펴보면, 다음과 같은 방식으로 byte 배열을 문자열로 변환합니다
     ```java
      public static String toString(byte[] a) {
          if (a == null)
              return "null";
          int iMax = a.length - 1;
          if (iMax == -1)
              return "[]";
  
          StringBuilder b = new StringBuilder();
          b.append('[');
          for (int i = 0; ; i++) {
              b.append(a[i]);
              if (i == iMax)
                  return b.append(']').toString();
              b.append(", ");
          }
      }
    ```
    - 이 코드에서는 byte 배열을 문자열로 다시 변환하는 것이 아니라 byte 배열의 각 값을 ,로 구분하여 나열하는 형식으로 변환하고 있기 때문에예상한 결과를 얻지 못했습니다.
- 해결된 코드
     ```java
      String data = new String(keys.next());
     ```
    - new String() 은 byte 배열을 지정된 문자셋(UTF-8)으로 변환하기 때문에 원하는 결과를 얻을 수 있었습니다.
       ```java
        public String(byte[] bytes) {
            this(Charset.defaultCharset(), bytes, 0, bytes.length);
        }
       ```
       ```java
        public static Charset defaultCharset() {
            if (defaultCharset == null) {
                synchronized (Charset.class) {
                    // do not look for providers other than the standard one
                    Charset cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
                    if (cs != null)
                        defaultCharset = cs;
                    else
                        defaultCharset = sun.nio.cs.UTF_8.INSTANCE;
                }
            }
            return defaultCharset;
      }
       ```
### 결론
- Arrays.toString()과 new String()의 차이를 알지 못하여 생긴 오류이다.