### PR TITLE
refactor: 조회수 중복 방지 및 메서드 분리, 에러 해결

### DIFF
--- a/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/petstable/domain/board/controller/BoardController.java
@@ -78,7 +78,7 @@ public class BoardController implements BoardApi {
 
     @GetMapping("/{boardId}")
     public PetsTableApiResponse<BoardDetailReadResponse> getPostDetail(@LoginUserId Long memberId, @PathVariable("boardId") Long boardId) {
-        recipeViewCntService.incrementViewCount(boardId);
+        recipeViewCntService.updateViewCount(memberId, boardId);
         BoardDetailReadResponse response = boardService.findDetailByBoardId(memberId, boardId);
         return PetsTableApiResponse.createResponse(response, GET_POST_DETAIL_SUCCESS);
     }

--- a/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
+++ b/src/main/java/com/example/petstable/domain/board/dto/response/BoardDetailReadResponse.java
@@ -23,13 +23,13 @@ public class BoardDetailReadResponse {
     private List<TagResponse> tags;
     private List<IngredientResponse> ingredients;
 
-    public static BoardDetailReadResponse from(BoardEntity boardEntity, boolean status, AmazonConfig amazonConfig) {
+    public static BoardDetailReadResponse from(BoardEntity boardEntity, boolean status, int viewCnt, AmazonConfig amazonConfig) {
         return BoardDetailReadResponse.builder()
                 .id(boardEntity.getId())
                 .title(boardEntity.getTitle())
                 .thumbnail(updateThumbnailUrlIfNeeded(boardEntity.getThumbnail_url() + "?size=thumbnail", amazonConfig))
                 .author(boardEntity.getMember().getNickName())
-                .viewCount(boardEntity.getView_count())
+                .viewCount(viewCnt)
                 .createdAt(boardEntity.getCreatedTime())
                 .bookmarkStatus(status)
                 .details(boardEntity.getDetails().stream()

--- a/src/main/java/com/example/petstable/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/BoardService.java
@@ -45,6 +45,7 @@ public class BoardService {
     private final AmazonConfig amazonConfig;
     private final AsyncService asyncService;
     private final BoardRollbackService boardRollbackService;
+    private final RecipeViewCntService recipeViewCntService;
 
     @Transactional
     public BoardPostResponse writePost(Long memberId, BoardPostRequest request, MultipartFile thumbnail, List<MultipartFile> images) {
@@ -247,7 +248,8 @@ public class BoardService {
         BoardEntity boardEntity = boardRepository.findById(boardId)
                 .orElseThrow(() -> new PetsTableException(POST_NOT_FOUND.getStatus(), POST_NOT_FOUND.getMessage(), 404));
         boolean isBookmarked = bookmarkRepository.existsByMemberIdAndPostId(memberId, boardId);
-        return BoardDetailReadResponse.from(boardEntity, isBookmarked, amazonConfig);
+        int viewCnt = recipeViewCntService.getViewCnt(boardId);
+        return BoardDetailReadResponse.from(boardEntity, isBookmarked, viewCnt, amazonConfig);
     }
 
     @Transactional

--- a/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
+++ b/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java
@@ -19,18 +19,41 @@ import java.time.Duration;
 public class RecipeViewCntService {
     private final RedisTemplate<String, String> redisTemplateForCluster;
     private static final String KEY_PREFIX = "recipe-views";
+    private static final String MEMBER_KEY_PREFIX = "viewer";
     private final BoardRepository boardRepository;
 
     @Transactional
-    public void incrementViewCount(Long postId) {
+    public void updateViewCount(Long memberId, Long postId) {
+        if (hasAlreadyViewed(memberId, postId)) {
+            log.warn("Member [{}] has already viewed post [{}]", memberId, postId);
+        } else {
+            int updatedViewCount = incrementViewCountInRedis(postId);
+            addMemberViewRecord(memberId, postId);
+            log.info("Updated view count for post [{}]: [{}]", postId, updatedViewCount);
+        }
+    }
+
+    public int incrementViewCountInRedis(Long postId) {
         String key = KEY_PREFIX + ":" + postId;
         ValueOperations<String, String> valueOperations = redisTemplateForCluster.opsForValue();
         if (valueOperations.get(key) == null) {
-            valueOperations.set(key, String.valueOf(boardRepository.findViewCntByPostId(postId)), Duration.ofMinutes(5));
+            String viewCount = String.valueOf(boardRepository.findViewCntByPostId(postId));
+            valueOperations.set(key, viewCount, Duration.ofMinutes(5));
         }
-        valueOperations.increment(key);
-        log.info("value:{}", valueOperations.get(key));
+        int incrementViewCount = valueOperations.increment(key).intValue();
+        log.info("Incremented view count for post [{}]: [{}]", postId, incrementViewCount);
+        return incrementViewCount;
     }
+
+    public boolean hasAlreadyViewed(Long memberId, Long postId) {
+        return Boolean.TRUE.equals(redisTemplateForCluster.opsForSet().isMember(MEMBER_KEY_PREFIX + ":" + memberId, postId.toString()));
+    }
+
+    public void addMemberViewRecord(Long memberId, Long postId) {
+        redisTemplateForCluster.opsForSet().add(MEMBER_KEY_PREFIX + ":" + memberId, postId.toString());
+        log.info("Added view record for member [{}] on post [{}]", memberId, postId);
+    }
+
 
     @Transactional
     public void syncViewCountsFromRedis() {
@@ -50,6 +73,15 @@ public class RecipeViewCntService {
             } else {
                 log.info("No data found for key: {}", data);
             }
+        }
+    }
+
+    public int getViewCnt(Long postId) {
+        String viewCnt = redisTemplateForCluster.opsForValue().get(KEY_PREFIX + ":" + postId);
+        if (viewCnt == null) {
+            return boardRepository.findViewCntByPostId(postId);
+        } else {
+            return Integer.parseInt(viewCnt);
         }
     }
 }

--- a/src/main/java/com/example/petstable/global/scheduler/ViewCountScheduler.java
+++ b/src/main/java/com/example/petstable/global/scheduler/ViewCountScheduler.java
@@ -1,0 +1,17 @@
+package com.example.petstable.global.scheduler;
+
+import com.example.petstable.domain.board.service.RecipeViewCntService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+    private final RecipeViewCntService recipeViewCntService;
+
+    @Scheduled(cron = "0 0/3 * * * ?")
+    public void syncViewCounts() {
+        recipeViewCntService.syncViewCountsFromRedis();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [chore: Redis에서 조회수 관련 로직 개선 및 오류 해결 #120 ](https://github.com/Graduate-PetsTable/PetsTable-backend/issues/120)

## 📝작업 내용
- `TransactionRequiredException: Executing an update/delete query` 에러는 트랜잭션 처리를 해주지 않아 발생한 문제이기 때문에 스케줄러 로직과 서비스 로직을 분리하고 트랜잭션을 적용해주었다.
  - 서비스 로직 ( 트랜잭션 적용 )
    - https://github.com/Graduate-PetsTable/PetsTable-backend/blob/b158dcd056ec0cd9082cd2729c17c5aac2cd9102/src/main/java/com/example/petstable/domain/board/service/RecipeViewCntService.java#L35-L54
  - 스케줄러 로직 ( 15분 -> 3분 )
    - https://github.com/Graduate-PetsTable/PetsTable-backend/blob/b158dcd056ec0cd9082cd2729c17c5aac2cd9102/src/main/java/com/example/petstable/global/scheduler/ViewCountScheduler.java#L8-L17
- 조회수 증가 중복 방지 및 메서드 분리 : 한 회원이 같은 게시글에 대해 24시간 동안 1회만 조회수 증가 가능
  - ```java
    @Transactional
    public void updateViewCount(Long memberId, Long postId) {
        if (hasAlreadyViewed(memberId, postId)) {
            log.warn("Member [{}] has already viewed post [{}]", memberId, postId);
        } else {
            int updatedViewCount = incrementViewCountInRedis(postId);
            addMemberViewRecord(memberId, postId);
            log.info("Updated view count for post [{}]: [{}]", postId, updatedViewCount);
        }
    }

    public int incrementViewCountInRedis(Long postId) {
        String key = KEY_PREFIX + ":" + postId;
        ValueOperations<String, String> valueOperations = redisTemplateForCluster.opsForValue();
        if (valueOperations.get(key) == null) {
            String viewCount = String.valueOf(boardRepository.findViewCntByPostId(postId));
            valueOperations.set(key, viewCount, Duration.ofMinutes(5));
        }
        int incrementViewCount = valueOperations.increment(key).intValue();
        log.info("Incremented view count for post [{}]: [{}]", postId, incrementViewCount);
        return incrementViewCount;
    }

    public boolean hasAlreadyViewed(Long memberId, Long postId) {
        return Boolean.TRUE.equals(redisTemplateForCluster.opsForSet().isMember(MEMBER_KEY_PREFIX + ":" + memberId, postId.toString()));
    }

    public void addMemberViewRecord(Long memberId, Long postId) {
        redisTemplateForCluster.opsForSet().add(MEMBER_KEY_PREFIX + ":" + memberId, postId.toString());
        log.info("Added view record for member [{}] on post [{}]", memberId, postId);
    }
  - addMemberViewRecord : Redis의 viewer:{memberId} 키에 게시글 ID 추가하고 유효시간을 24시간으로 설정
  - hasAlreadyViewed : Redis의 viewer:{memberId} 키에 게시글 ID가 포함되어 있는지 확인
  - incrementViewCountInRedis : Redis에 게시글의 조회수 키가 없을 경우, DB에서 조회수를 가져와 초기화 및 조회수 증가 시 Redis에 바로 반영.